### PR TITLE
Set the PBR material feature for obj materials containing Pr/Pm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   ci_pre_hashes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Compile hash_scene
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Update apt
@@ -71,7 +71,7 @@ jobs:
     runs-on: windows-2019
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download reference hashes
         uses: actions/download-artifact@v3
         with:
@@ -96,7 +96,7 @@ jobs:
     runs-on: macos-11
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download reference hashes
         uses: actions/download-artifact@v3
         with:
@@ -119,7 +119,7 @@ jobs:
   ci_picort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run picort
         run: python misc/run_tests.py picort
       - name: Upload result images
@@ -141,28 +141,28 @@ jobs:
   ci_domfuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run domfuzz/objfuzz
         run: python misc/run_tests.py domfuzz objfuzz
 
   ci_viewer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run viewer
         run: python misc/run_tests.py viewer
 
   ci_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Compile feature permutations
         run: python misc/run_tests.py features
 
   ci_analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update apt
         run: sudo apt-get update
       - name: Install apt dependencies
@@ -207,7 +207,7 @@ jobs:
   ci_bindgen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create bindgen/build directory
         run: mkdir bindgen/build
       - name: Parse ufbx.h
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download reference hashes
         uses: actions/download-artifact@v3
         with:
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Prepare directories
         run: |
           mkdir build
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install wasi-sdk
         run: |
           mkdir build
@@ -375,7 +375,7 @@ jobs:
     runs-on: [self-hosted, ARM]
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Download reference hashes
@@ -399,7 +399,7 @@ jobs:
     runs-on: [self-hosted, ARM64]
     needs: ci_pre_hashes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Download reference hashes
@@ -422,7 +422,7 @@ jobs:
   ci_dataset:
     runs-on: [self-hosted, ARM64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Create build directory
@@ -437,7 +437,7 @@ jobs:
     if: ${{ always() }}
     needs: [ci_ubuntu, ci_windows, ci_macos, ci_wasm, ci_arm32, ci_arm64, ci_exotic, ci_hasher]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Compile hash_scene

--- a/test/test_obj.h
+++ b/test/test_obj.h
@@ -488,6 +488,15 @@ UFBXT_FILE_TEST(synthetic_simple_materials)
 		ufbxt_assert(mat->pbr.base_factor.value_real == 1.0f);
 		ufbxt_assert(mat->pbr.specular_factor.value_real == 1.0f);
 		ufbxt_assert(mat->pbr.emission_factor.value_real == 1.0f);
+
+		ufbxt_assert(mat->features.diffuse.enabled);
+		ufbxt_assert(mat->features.specular.enabled);
+		ufbxt_assert(mat->features.opacity.enabled);
+		ufbxt_assert(!mat->features.pbr.enabled);
+		ufbxt_assert(!mat->features.metalness.enabled);
+		ufbxt_assert(!mat->features.sheen.enabled);
+		ufbxt_assert(!mat->features.coat.enabled);
+		ufbxt_assert(!mat->features.transmission.enabled);
 	}
 
 	{
@@ -516,6 +525,7 @@ UFBXT_FILE_TEST(synthetic_simple_materials)
 		ufbxt_assert(mat->pbr.sheen_factor.value_real == 1.0f);
 		ufbxt_assert(mat->pbr.transmission_factor.value_real == 1.0f);
 
+		ufbxt_assert(mat->features.pbr.enabled);
 		ufbxt_assert(mat->features.metalness.enabled);
 		ufbxt_assert(mat->features.diffuse.enabled);
 		ufbxt_assert(mat->features.specular.enabled);

--- a/ufbx.c
+++ b/ufbx.c
@@ -16545,6 +16545,8 @@ static const ufbxi_shader_mapping ufbxi_obj_pbr_mapping[] = {
 };
 
 static const ufbxi_shader_mapping ufbxi_obj_features[] = {
+	{ UFBX_MATERIAL_FEATURE_PBR, UFBXI_SHADER_FEATURE_IF_EXISTS, 0, ufbxi_mat_string("Pr") },
+	{ UFBX_MATERIAL_FEATURE_PBR, UFBXI_SHADER_FEATURE_IF_EXISTS, 0, ufbxi_mat_string("Pm") },
 	{ UFBX_MATERIAL_FEATURE_SHEEN, UFBXI_SHADER_FEATURE_IF_EXISTS, 0, ufbxi_mat_string("Ps") },
 	{ UFBX_MATERIAL_FEATURE_COAT, UFBXI_SHADER_FEATURE_IF_EXISTS, 0, ufbxi_mat_string("Pc") },
 	{ UFBX_MATERIAL_FEATURE_METALNESS, UFBXI_SHADER_FEATURE_IF_EXISTS, 0, ufbxi_mat_string("Pm") },

--- a/ufbx.c
+++ b/ufbx.c
@@ -658,7 +658,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 2, 1)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 2, 2)
 const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);

--- a/ufbx.h
+++ b/ufbx.h
@@ -161,7 +161,7 @@ typedef double ufbx_real;
 #define ufbx_version_minor(version) ((uint32_t)(version)/1000u%1000u)
 #define ufbx_version_patch(version) ((uint32_t)(version)%1000u)
 
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 2, 1)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 2, 2)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types


### PR DESCRIPTION
obj files have non-standard extensions for PBR material properties but doesn't differentiate them from the basic Phong ones. Detect if Pr (roughness) or Pm (metalness) exists and enable the PBR feature in that case.