### PR TITLE
Test dataset materials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,22 @@ jobs:
         if: ${{ always() && !cancelled() }}
         run: python3 misc/analyze_stack.py build/ufbx-gcc-release.su --limit 0x10000 --cache build/ufbx-cache.pickle
 
+  ci_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check formatting
+        if: ${{ always() && !cancelled() }}
+        run: python3 misc/check_formatting.py ufbx.c ufbx.h
+      - name: Check for typos
+        if: ${{ always() && !cancelled() }}
+        uses: crate-ci/typos@master
+        with: 
+          files:
+            - ./ufbx.h
+            - ./ufbx.c
+          config: ./misc/typos.toml
+
   ci_bindgen:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Run tests with old header (source compatability)
         run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat
       - name: Run tests with new header in ufbx.c, old header in runner.c (ABI compatability)
-        run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat --define UFBX_HEADER_PATH=\"ufbx_new.h\"
+        run: python3 misc/run_tests.py tests --runner ci_compat --define UFBX_HEADER_PATH=\"ufbx_new.h\"
 
   ci_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
       - name: Downgrade to oldest compatible header
         run: bash misc/downgrade_header.sh
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Fetch tags
-        run: git fetch --prune --unshallow --tags
+        with:
+          fetch-depth: 0
       - name: Downgrade to oldest compatible header
         run: bash misc/downgrade_header.sh
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Update apt
-        run: sudo apt-get update
-      - name: Install apt dependencies
-        run: sudo apt-get install -y gcc-multilib g++-multilib
       - name: Copy the current ufbx.h to ufbx_new.h
         run: cp ufbx.h ufbx_new.h
       - name: Downgrade to oldest compatible header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,17 @@ jobs:
         if: ${{ always() && !cancelled() }}
         run: python3 misc/analyze_stack.py build/ufbx-gcc-release.su --limit 0x10000 --cache build/ufbx-cache.pickle
 
+  ci_compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Downgrade to oldest compatible header
+        run: bash misc/downgrade_header.sh
+      - name: Run tests
+        run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat
+
   ci_lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,9 +215,7 @@ jobs:
         if: ${{ always() && !cancelled() }}
         uses: crate-ci/typos@master
         with: 
-          files:
-            - ./ufbx.h
-            - ./ufbx.c
+          files: ufbx.h ufbx.c
           config: ./misc/typos.toml
 
   ci_bindgen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
       - name: Downgrade to oldest compatible header
         run: bash misc/downgrade_header.sh
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install apt dependencies
+        run: sudo apt-get install -y gcc-multilib g++-multilib
       - name: Copy the current ufbx.h to ufbx_new.h
         run: cp ufbx.h ufbx_new.h
       - name: Downgrade to oldest compatible header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install apt dependencies
+        run: sudo apt-get install -y gcc-multilib g++-multilib
       - name: Copy the current ufbx.h to ufbx_new.h
         run: cp ufbx.h ufbx_new.h
       - name: Downgrade to oldest compatible header
@@ -217,7 +221,7 @@ jobs:
       - name: Run tests with old header (source compatability)
         run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat
       - name: Run tests with new header in ufbx.c, old header in runner.c (ABI compatability)
-        run: python3 misc/run_tests.py tests --runner ci_compat --define UFBX_HEADER_PATH=\"ufbx_new.h\"
+        run: python3 misc/run_tests.py tests --no-sanitize-arch x86 --runner ci_compat --define UFBX_HEADER_PATH=\"ufbx_new.h\"
 
   ci_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Copy the current ufbx.h to ufbx_new.h
+        run: cp ufbx.h ufbx_new.h
       - name: Downgrade to oldest compatible header
         run: bash misc/downgrade_header.sh
-      - name: Run tests
+      - name: Run tests with old header (source compatability)
         run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat
+      - name: Run tests with new header in ufbx.c, old header in runner.c (ABI compatability)
+        run: python3 misc/run_tests.py tests --no-sanitize --runner ci_compat --define UFBX_HEADER_PATH=\"ufbx_new.h\"
 
   ci_lint:
     runs-on: ubuntu-latest

--- a/misc/check_dataset.py
+++ b/misc/check_dataset.py
@@ -10,6 +10,7 @@ class TestModel(NamedTuple):
     fbx_path: str
     obj_path: Optional[str]
     mtl_path: Optional[str]
+    mat_path: Optional[str]
     frame: Optional[int]
 
 class TestCase(NamedTuple):
@@ -54,6 +55,10 @@ def get_mtl_files(obj_path):
     base_path = strip_ext(obj_path)
     yield from single_file(f"{base_path}.mtl")
 
+def get_mat_files(obj_path):
+    base_path = strip_ext(obj_path)
+    yield from single_file(f"{base_path}.mat")
+
 def remove_duplicate_files(paths):
     seen = set()
     for path in paths:
@@ -66,6 +71,7 @@ def gather_case_models(json_path):
     for fbx_path in get_fbx_files(json_path):
         for obj_path in remove_duplicate_files(get_obj_files(fbx_path)):
             mtl_path = next(get_mtl_files(obj_path), None)
+            mat_path = next(get_mat_files(fbx_path), None)
 
             fbx_base = strip_ext(fbx_path)
             obj_base = strip_ext(obj_path)
@@ -83,6 +89,7 @@ def gather_case_models(json_path):
                 fbx_path=fbx_path,
                 obj_path=obj_path,
                 mtl_path=mtl_path,
+                mat_path=mat_path,
                 frame=frame)
 
         else:
@@ -171,6 +178,9 @@ if __name__ == "__main__":
             if model.obj_path:
                 args += ["--obj", model.obj_path]
 
+            if model.mat_path:
+                args += ["--mat", model.mat_path]
+
             if model.frame is not None:
                 extra.append(f"frame {model.frame}")
                 args += ["--frame", str(model.frame)]
@@ -189,6 +199,8 @@ if __name__ == "__main__":
                     log(f"    .obj url: {fmt_url(model.obj_path, case.root)}")
                 if model.mtl_path:
                     log(f"    .mtl url: {fmt_url(model.mtl_path, case.root)}")
+                if model.mat_path:
+                    log(f"    .mat url: {fmt_url(model.mat_path, case.root)}")
 
             log()
             log("$ " + " ".join(args))

--- a/misc/check_formatting.py
+++ b/misc/check_formatting.py
@@ -77,6 +77,11 @@ if __name__ == "__main__":
     p.add_argument("--no-color", action="store_true")
     argv = p.parse_args()
 
+    failed = False
     colors = not argv.no_color and sys.stdout.isatty()
     for f in argv.files:
-        check_file(f, colors)
+        if check_file(f, colors):
+            failed = True
+
+    if failed:
+        sys.exit(1)

--- a/misc/check_formatting.py
+++ b/misc/check_formatting.py
@@ -1,0 +1,82 @@
+import argparse
+import re
+import sys
+
+def strip_comments(line):
+    if "//" in line:
+        return line[:line.index("//")]
+    else:
+        return line
+
+def forbid(r, line, err):
+    m = re.search(r, line)
+    if m:
+        return (err, m.start(1), m.end(1))
+    else:
+        return None
+
+def no_trailing_whitespace(line):
+    return forbid(r"(\s+)$", line, "trailing whitespace is forbidden")
+
+def indent_tabs(line):
+    return forbid(r"^\s*?( +)\s*", line, "tabs should be used for indentation")
+
+def no_trailing_tabs(line):
+    return forbid(r"\S.*(\t+)", line, "tabs should only appear in the beginning of a line")
+
+def keyword_spacing(line):
+    line = strip_comments(line)
+    return forbid(r"\b(?:for|if|while)(\()", line, "expected space after keyword")
+
+def pointer_alignment(line):
+    line = strip_comments(line)
+    return forbid(r"\w(\* )\w", line, "pointers should be aligned to the right")
+
+checks = [
+    no_trailing_whitespace,
+    indent_tabs,
+    no_trailing_tabs,
+    keyword_spacing,
+    pointer_alignment,
+]
+
+def check_file(path, colors):
+    failed = False
+    if colors:
+        c_gray = "\033[1;30m"
+        c_green = "\033[1;32m"
+        c_red = "\033[1;31m"
+        c_white = "\033[1;97m"
+        c_def = "\033[0m"
+    else:
+        c_gray = ""
+        c_green = ""
+        c_red = ""
+        c_white = ""
+        c_def = ""
+    with open(path, "rt") as f:
+        for ix, line in enumerate(f):
+            line = line.rstrip("\r\n")
+            for check in checks:
+                err = check(line)
+                if err:
+                    err_desc, err_begin, err_end = err
+                    l = f"{c_white}{path}:{ix + 1}:{err_begin + 1}: {c_red}error:{c_white} {err_desc} [{check.__name__}]{c_def}"
+                    s = line
+                    s = s.replace("\t", f"{c_gray}\u2192{c_def}")
+                    s = s.replace(" ", f"{c_gray}\u00B7{c_def}")
+                    e = " " * err_begin + c_green + "^" * (err_end - err_begin) + c_def
+                    print(f"{l}\n  {s}\n  {e}")
+                    failed = True
+    return failed
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser("check_formatting.py")
+    p.add_argument("files", nargs="*")
+    p.add_argument("--no-color", action="store_true")
+    argv = p.parse_args()
+
+    colors = not argv.no_color and sys.stdout.isatty()
+    for f in argv.files:
+        check_file(f, colors)

--- a/misc/downgrade_header.sh
+++ b/misc/downgrade_header.sh
@@ -9,7 +9,7 @@ if [[ "$TAG" == v*.*.0 ]]; then
     echo "No older header available"
 elif [[ "$TAG" == v*.*.* ]]; then
     OLD_TAG="${TAG%.*}".0
-    OLD_COMMIT=$(git rev-parse "$OLD_TAG")
+    OLD_COMMIT=$( set -x; git rev-parse "$OLD_TAG" )
     echo "Downgrading ufbx.h to tag $OLD_TAG, commit $OLD_COMMIT"
     ( set -x; git checkout "$OLD_TAG" -- ufbx.h )
 else

--- a/misc/downgrade_header.sh
+++ b/misc/downgrade_header.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+TAG=$( set -x; python3 misc/get_header_tag.py )
+
+echo "Header version tag: $TAG"
+if [[ "$TAG" == v*.*.0 ]]; then
+    echo "No older header available"
+elif [[ "$TAG" == v*.*.* ]]; then
+    OLD_TAG="${TAG%.*}".0
+    OLD_COMMIT=$(git rev-parse "$OLD_TAG")
+    echo "Downgrading ufbx.h to tag $OLD_TAG, commit $OLD_COMMIT"
+    ( set -x; git checkout "$OLD_TAG" -- ufbx.h )
+else
+    echo "Error: Malformed tag \"$TAG\""
+    exit 1
+fi

--- a/misc/downgrade_header.sh
+++ b/misc/downgrade_header.sh
@@ -9,7 +9,7 @@ if [[ "$TAG" == v*.*.0 ]]; then
     echo "No older header available"
 elif [[ "$TAG" == v*.*.* ]]; then
     OLD_TAG="${TAG%.*}".0
-    OLD_COMMIT=$( set -x; git rev-parse "$OLD_TAG" )
+    OLD_COMMIT=$( set -x; git rev-list -n 1 "$OLD_TAG" )
     echo "Downgrading ufbx.h to tag $OLD_TAG, commit $OLD_COMMIT"
     ( set -x; git checkout "$OLD_TAG" -- ufbx.h )
 else

--- a/misc/get_header_tag.py
+++ b/misc/get_header_tag.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+self_path = os.path.dirname(__file__)
+ufbx_path = os.path.join(self_path, "..", "ufbx.h")
+
+if __name__ == "__main__":
+    version = None
+    with open(ufbx_path, "rt") as f:
+        for line in f:
+            m = re.match(r"#define\s+UFBX_HEADER_VERSION\s+ufbx_pack_version\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*", line)
+            if m:
+                version = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+                break
+
+    if not version:
+        raise RuntimeError("Could not find version from header")
+
+    major, minor, patch = version
+    print(f"v{major}.{minor}.{patch}")

--- a/misc/run_tests.py
+++ b/misc/run_tests.py
@@ -19,6 +19,7 @@ parser.add_argument("--additional-compiler", default=[], action="append", help="
 parser.add_argument("--remove-compiler", default=[], action="append", help="Remove a compiler from being used")
 parser.add_argument("--remove-arch", default=[], action="append", help="Remove an architecture")
 parser.add_argument("--compiler", default=[], action="append", help="Specify exact compiler(s) to use")
+parser.add_argument("--define", default=[], action="append", help="Define preprocessor symbols")
 parser.add_argument("--no-sse", action="store_true", help="Don't make SSE builds when possible")
 parser.add_argument("--wasi-sdk", default=[], action="append", help="WASI SDK path")
 parser.add_argument("--wasm-runtime", default="wasmtime", type=str, help="WASM runtime command")
@@ -765,6 +766,16 @@ async def main():
                 conf = copy.deepcopy(config)
                 conf["output"] = os.path.join(path, config.get("output", "a.exe"))
 
+                if "defines" not in conf:
+                    conf["defines"] = { }
+
+                if not conf.get("ignore_user_defines", False):
+                    for k in argv.define:
+                        v = "1"
+                        if "=" in k:
+                            k, v = k.split("=", 1)
+                        conf["defines"][k] = v
+
                 for opt_name, opt in opts:
                     conf.update(config_options[opt_name][opt])
 
@@ -793,6 +804,7 @@ async def main():
         "sources": ["misc/compiler_test.c"],
         "output": "ctest" + exe_suffix,
         "arch_test": True,
+        "ignore_user_defines": True,
     }
     ctest_tasks += compile_permutations("ctest", ctest_config, arch_test_configs, ["1.5"])
 
@@ -801,6 +813,7 @@ async def main():
         "output": "cpptest" + exe_suffix,
         "cpp": True,
         "arch_test": True,
+        "ignore_user_defines": True,
     }
     ctest_tasks += compile_permutations("cpptest", cpptest_config, arch_test_configs, ["1.5"])
 

--- a/misc/run_tests.py
+++ b/misc/run_tests.py
@@ -24,6 +24,7 @@ parser.add_argument("--no-sse", action="store_true", help="Don't make SSE builds
 parser.add_argument("--wasi-sdk", default=[], action="append", help="WASI SDK path")
 parser.add_argument("--wasm-runtime", default="wasmtime", type=str, help="WASM runtime command")
 parser.add_argument("--no-sanitize", action="store_true", help="Don't compile builds with ASAN/UBSAN")
+parser.add_argument("--no-sanitize-arch", default=[], action="append", help="Disable sanitization on specific architectures")
 parser.add_argument("--threads", type=int, default=0, help="Number of threads to use (0 to autodetect)")
 parser.add_argument("--verbose", action="store_true", help="Verbose output")
 parser.add_argument("--hash-file", help="Hash test input file")
@@ -486,6 +487,8 @@ def supported_archs(compiler):
     archs = compiler.supported_archs()
     if argv.no_sanitize:
         archs = [a for a in archs if not a.endswith("-san")]
+    if argv.no_sanitize_arch:
+        archs = [a for a in archs if not a.endswith("-san") or a[:-4] not in argv.no_sanitize_arch]
     return archs
 
 all_compilers = [

--- a/misc/typos.toml
+++ b/misc/typos.toml
@@ -1,0 +1,14 @@
+[default.extend-identifiers]
+
+# Offset Translation
+OT = "OT"
+
+# Typos in the FBX fileformat
+PreferedAngleX = "PreferedAngleX"
+PreferedAngleY = "PreferedAngleY"
+PreferedAngleZ = "PreferedAngleZ"
+
+[default.extend-words]
+
+# Level of Detail
+lod = "lod"

--- a/test/check_material.h
+++ b/test/check_material.h
@@ -1,0 +1,472 @@
+#ifndef UFBXT_CHECK_MATERIAL_H_INCLUDED
+#define UFBXT_CHECK_MATERIAL_H_INCLUDED
+
+#include "../ufbx.h"
+#include <stdlib.h>
+
+static const char *ufbxt_fbx_map_name(ufbx_material_fbx_map map)
+{
+	switch (map) {
+	case UFBX_MATERIAL_FBX_DIFFUSE_FACTOR: return "diffuse_factor";
+	case UFBX_MATERIAL_FBX_DIFFUSE_COLOR: return "diffuse_color";
+	case UFBX_MATERIAL_FBX_SPECULAR_FACTOR: return "specular_factor";
+	case UFBX_MATERIAL_FBX_SPECULAR_COLOR: return "specular_color";
+	case UFBX_MATERIAL_FBX_SPECULAR_EXPONENT: return "specular_exponent";
+	case UFBX_MATERIAL_FBX_REFLECTION_FACTOR: return "reflection_factor";
+	case UFBX_MATERIAL_FBX_REFLECTION_COLOR: return "reflection_color";
+	case UFBX_MATERIAL_FBX_TRANSPARENCY_FACTOR: return "transparency_factor";
+	case UFBX_MATERIAL_FBX_TRANSPARENCY_COLOR: return "transparency_color";
+	case UFBX_MATERIAL_FBX_EMISSION_FACTOR: return "emission_factor";
+	case UFBX_MATERIAL_FBX_EMISSION_COLOR: return "emission_color";
+	case UFBX_MATERIAL_FBX_AMBIENT_FACTOR: return "ambient_factor";
+	case UFBX_MATERIAL_FBX_AMBIENT_COLOR: return "ambient_color";
+	case UFBX_MATERIAL_FBX_NORMAL_MAP: return "normal_map";
+	case UFBX_MATERIAL_FBX_BUMP: return "bump";
+	case UFBX_MATERIAL_FBX_BUMP_FACTOR: return "bump_factor";
+	case UFBX_MATERIAL_FBX_DISPLACEMENT_FACTOR: return "displacement_factor";
+	case UFBX_MATERIAL_FBX_DISPLACEMENT: return "displacement";
+	case UFBX_MATERIAL_FBX_VECTOR_DISPLACEMENT_FACTOR: return "vector_displacement_factor";
+	case UFBX_MATERIAL_FBX_VECTOR_DISPLACEMENT: return "vector_displacement";
+	}
+
+	ufbxt_assert(0 && "Unhandled PBR map name");
+	return NULL;
+}
+
+static const char *ufbxt_pbr_map_name(ufbx_material_pbr_map map)
+{
+	switch (map) {
+	case UFBX_MATERIAL_PBR_BASE_FACTOR: return "base_factor";
+	case UFBX_MATERIAL_PBR_BASE_COLOR: return "base_color";
+	case UFBX_MATERIAL_PBR_ROUGHNESS: return "roughness";
+	case UFBX_MATERIAL_PBR_METALNESS: return "metalness";
+	case UFBX_MATERIAL_PBR_DIFFUSE_ROUGHNESS: return "diffuse_roughness";
+	case UFBX_MATERIAL_PBR_SPECULAR_FACTOR: return "specular_factor";
+	case UFBX_MATERIAL_PBR_SPECULAR_COLOR: return "specular_color";
+	case UFBX_MATERIAL_PBR_SPECULAR_IOR: return "specular_ior";
+	case UFBX_MATERIAL_PBR_SPECULAR_ANISOTROPY: return "specular_anisotropy";
+	case UFBX_MATERIAL_PBR_SPECULAR_ROTATION: return "specular_rotation";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_FACTOR: return "transmission_factor";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_COLOR: return "transmission_color";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_DEPTH: return "transmission_depth";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_SCATTER: return "transmission_scatter";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_SCATTER_ANISOTROPY: return "transmission_scatter_anisotropy";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_DISPERSION: return "transmission_dispersion";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_ROUGHNESS: return "transmission_roughness";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_EXTRA_ROUGHNESS: return "transmission_extra_roughness";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_PRIORITY: return "transmission_priority";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_ENABLE_IN_AOV: return "transmission_enable_in_aov";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_FACTOR: return "subsurface_factor";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_COLOR: return "subsurface_color";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_RADIUS: return "subsurface_radius";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_SCALE: return "subsurface_scale";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_ANISOTROPY: return "subsurface_anisotropy";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_TINT_COLOR: return "subsurface_tint_color";
+	case UFBX_MATERIAL_PBR_SUBSURFACE_TYPE: return "subsurface_type";
+	case UFBX_MATERIAL_PBR_SHEEN_FACTOR: return "sheen_factor";
+	case UFBX_MATERIAL_PBR_SHEEN_COLOR: return "sheen_color";
+	case UFBX_MATERIAL_PBR_SHEEN_ROUGHNESS: return "sheen_roughness";
+	case UFBX_MATERIAL_PBR_COAT_FACTOR: return "coat_factor";
+	case UFBX_MATERIAL_PBR_COAT_COLOR: return "coat_color";
+	case UFBX_MATERIAL_PBR_COAT_ROUGHNESS: return "coat_roughness";
+	case UFBX_MATERIAL_PBR_COAT_IOR: return "coat_ior";
+	case UFBX_MATERIAL_PBR_COAT_ANISOTROPY: return "coat_anisotropy";
+	case UFBX_MATERIAL_PBR_COAT_ROTATION: return "coat_rotation";
+	case UFBX_MATERIAL_PBR_COAT_NORMAL: return "coat_normal";
+	case UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_COLOR: return "coat_affect_base_color";
+	case UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_ROUGHNESS: return "coat_affect_base_roughness";
+	case UFBX_MATERIAL_PBR_THIN_FILM_THICKNESS: return "thin_film_thickness";
+	case UFBX_MATERIAL_PBR_THIN_FILM_IOR: return "thin_film_ior";
+	case UFBX_MATERIAL_PBR_EMISSION_FACTOR: return "emission_factor";
+	case UFBX_MATERIAL_PBR_EMISSION_COLOR: return "emission_color";
+	case UFBX_MATERIAL_PBR_OPACITY: return "opacity";
+	case UFBX_MATERIAL_PBR_INDIRECT_DIFFUSE: return "indirect_diffuse";
+	case UFBX_MATERIAL_PBR_INDIRECT_SPECULAR: return "indirect_specular";
+	case UFBX_MATERIAL_PBR_NORMAL_MAP: return "normal_map";
+	case UFBX_MATERIAL_PBR_TANGENT_MAP: return "tangent_map";
+	case UFBX_MATERIAL_PBR_DISPLACEMENT_MAP: return "displacement_map";
+	case UFBX_MATERIAL_PBR_MATTE_FACTOR: return "matte_factor";
+	case UFBX_MATERIAL_PBR_MATTE_COLOR: return "matte_color";
+	case UFBX_MATERIAL_PBR_AMBIENT_OCCLUSION: return "ambient_occlusion";
+	case UFBX_MATERIAL_PBR_GLOSSINESS: return "glossiness";
+	case UFBX_MATERIAL_PBR_COAT_GLOSSINESS: return "coat_glossiness";
+	case UFBX_MATERIAL_PBR_TRANSMISSION_GLOSSINESS: return "transmission_glossiness";
+	}
+
+	ufbxt_assert(0 && "Unhandled PBR map name");
+	return 0;
+}
+
+static const char *ufbxt_material_feature_name(ufbx_material_pbr_map map)
+{
+	switch (map) {
+	case UFBX_MATERIAL_FEATURE_PBR: return "pbr";
+	case UFBX_MATERIAL_FEATURE_METALNESS: return "metalness";
+	case UFBX_MATERIAL_FEATURE_DIFFUSE: return "diffuse";
+	case UFBX_MATERIAL_FEATURE_SPECULAR: return "specular";
+	case UFBX_MATERIAL_FEATURE_EMISSION: return "emission";
+	case UFBX_MATERIAL_FEATURE_TRANSMISSION: return "transmission";
+	case UFBX_MATERIAL_FEATURE_COAT: return "coat";
+	case UFBX_MATERIAL_FEATURE_SHEEN: return "sheen";
+	case UFBX_MATERIAL_FEATURE_OPACITY: return "opacity";
+	case UFBX_MATERIAL_FEATURE_AMBIENT_OCCLUSION: return "ambient_occlusion";
+	case UFBX_MATERIAL_FEATURE_MATTE: return "matte";
+	case UFBX_MATERIAL_FEATURE_UNLIT: return "unlit";
+	case UFBX_MATERIAL_FEATURE_IOR: return "ior";
+	case UFBX_MATERIAL_FEATURE_DIFFUSE_ROUGHNESS: return "diffuse_roughness";
+	case UFBX_MATERIAL_FEATURE_TRANSMISSION_ROUGHNESS: return "transmission_roughness";
+	case UFBX_MATERIAL_FEATURE_THIN_WALLED: return "thin_walled";
+	case UFBX_MATERIAL_FEATURE_CAUSTICS: return "caustics";
+	case UFBX_MATERIAL_FEATURE_EXIT_TO_BACKGROUND: return "exit_to_background";
+	case UFBX_MATERIAL_FEATURE_INTERNAL_REFLECTIONS: return "internal_reflections";
+	case UFBX_MATERIAL_FEATURE_DOUBLE_SIDED: return "double_sided";
+	case UFBX_MATERIAL_FEATURE_ROUGHNESS_AS_GLOSSINESS: return "roughness_as_glossiness";
+	case UFBX_MATERIAL_FEATURE_COAT_ROUGHNESS_AS_GLOSSINESS: return "coat_roughness_as_glossiness";
+	case UFBX_MATERIAL_FEATURE_TRANSMISSION_ROUGHNESS_AS_GLOSSINESS: return "transmission_roughness_as_glossiness";
+	}
+
+	ufbxt_assert(0 && "Unhandled material feature name");
+	return 0;
+}
+
+static const char *ufbxt_shader_type_name(ufbx_shader_type map)
+{
+	switch (map) {
+	case UFBX_SHADER_UNKNOWN: return "unknown";
+	case UFBX_SHADER_FBX_LAMBERT: return "fbx_lambert";
+	case UFBX_SHADER_FBX_PHONG: return "fbx_phong";
+	case UFBX_SHADER_OSL_STANDARD_SURFACE: return "osl_standard_surface";
+	case UFBX_SHADER_ARNOLD_STANDARD_SURFACE: return "arnold_standard_surface";
+	case UFBX_SHADER_3DS_MAX_PHYSICAL_MATERIAL: return "3ds_max_physical_material";
+	case UFBX_SHADER_3DS_MAX_PBR_METAL_ROUGH: return "3ds_max_pbr_metal_rough";
+	case UFBX_SHADER_3DS_MAX_PBR_SPEC_GLOSS: return "3ds_max_pbr_spec_gloss";
+	case UFBX_SHADER_GLTF_MATERIAL: return "gltf_material";
+	case UFBX_SHADER_SHADERFX_GRAPH: return "shaderfx_graph";
+	case UFBX_SHADER_BLENDER_PHONG: return "blender_phong";
+	case UFBX_SHADER_WAVEFRONT_MTL: return "wavefront_mtl";
+	}
+
+	ufbxt_assert(0 && "Unhandled material feature name");
+	return 0;
+}
+
+static size_t ufbxt_tokenize_line(char *buf, size_t buf_len, const char **tokens, size_t max_tokens, const char **p_line, const char *sep_chars)
+{
+	bool prev_sep = true;
+
+	size_t num_tokens = 0;
+	size_t buf_pos = 0;
+
+	const char *p = *p_line;
+	for (;;) {
+		char c = *p;
+		if (c == '\0' || c == '\n') break;
+
+		bool sep = false;
+		for (const char *s = sep_chars; *s; s++) {
+			if (*s == c) {
+				sep = true;
+				break;
+			}
+		}
+
+		if (!sep) {
+			if (prev_sep) {
+				ufbxt_assert(buf_pos < buf_len);
+				buf[buf_pos++] = '\0';
+
+				ufbxt_assert(num_tokens < max_tokens);
+				tokens[num_tokens++] = buf + buf_pos;
+			}
+
+			ufbxt_assert(buf_pos < buf_len);
+			buf[buf_pos++] = c;
+		}
+		prev_sep = sep;
+		p++;
+	}
+
+	ufbxt_assert(buf_pos < buf_len);
+	buf[buf_pos++] = '\0';
+
+	for (size_t i = num_tokens; i < max_tokens; i++) {
+		tokens[i] = "";
+	}
+
+	if (*p == '\n') p += 1;
+	*p_line = p;
+
+	return num_tokens;
+}
+
+static bool ufbxt_check_materials(ufbx_scene *scene, const char *spec, const char *filename)
+{
+	bool ok = true;
+
+	char line_buf[512];
+	const char *tokens[8];
+
+	char dot_buf[512];
+	const char *dots[8];
+
+	ufbx_material *material = NULL;
+	size_t num_materials = 0;
+	size_t num_props = 0;
+
+	double err_sum = 0.0;
+	double err_max = 0.0;
+	size_t err_num = 0;
+
+	bool material_error = false;
+
+	long version = 0;
+
+	int line = 0;
+	while (*spec != '\0') {
+		size_t num_tokens = ufbxt_tokenize_line(line_buf, sizeof(line_buf), tokens, ufbxt_arraycount(tokens), &spec, " \t\r");
+		line++;
+
+		if (num_tokens == 0) continue;
+
+		const char *first_token = tokens[0];
+		size_t num_dots = ufbxt_tokenize_line(dot_buf, sizeof(dot_buf), dots, ufbxt_arraycount(dots), &first_token, ".");
+
+		if (!strcmp(dots[0], "version")) {
+			char *end = NULL;
+			version = strtol(tokens[1], &end, 10);
+			if (!end || *end != '\0') {
+				fprintf(stderr, "%s:%d: Bad value in '%s': '%s'\n", filename, line, tokens[0], tokens[1]);
+				ok = false;
+				continue;
+			}
+
+			continue;
+		} else if (!strcmp(dots[0], "material")) {
+			if (*tokens[1] == '\0') {
+				fprintf(stderr, "%s:%d: Expected material name for 'material'\n", filename, line);
+				ok = false;
+			}
+
+			material = ufbx_find_material(scene, tokens[1]);
+			if (!material) {
+				fprintf(stderr, "%s:%d: Material not found: '%s'\n", filename, line, tokens[1]);
+				ok = false;
+			}
+			material_error = !material;
+
+			num_materials++;
+			continue;
+		}
+
+		if (!material) {
+			if (!material_error) {
+				fprintf(stderr, "%s:%d: Statement '%s' needs to have a material defined\n", filename, line, tokens[0]);
+			}
+			ok = false;
+			continue;
+		}
+
+		num_props++;
+
+		if (!strcmp(dots[0], "fbx") || !strcmp(dots[0], "pbr")) {
+			ufbx_material_map *map = NULL;
+			if (!strcmp(dots[0], "fbx")) {
+				ufbx_material_fbx_map name = (ufbx_material_fbx_map)UFBX_MATERIAL_FBX_MAP_COUNT;
+				for (size_t i = 0; i < UFBX_MATERIAL_FBX_MAP_COUNT; i++) {
+					const char *str = ufbxt_fbx_map_name((ufbx_material_fbx_map)i);
+					if (!strcmp(dots[1], str)) {
+						name = (ufbx_material_fbx_map)i;
+						break;
+					}
+				}
+				if (name == (ufbx_material_fbx_map)UFBX_MATERIAL_FBX_MAP_COUNT) {
+					fprintf(stderr, "%s:%d: Unknown FBX material map '%s' in '%s'\n", filename, line, dots[1], tokens[0]);
+					ok = false;
+				} else {
+					map = &material->fbx.maps[name];
+				}
+			} else if (!strcmp(dots[0], "pbr")) {
+				ufbx_material_pbr_map name = (ufbx_material_pbr_map)UFBX_MATERIAL_PBR_MAP_COUNT;
+				for (size_t i = 0; i < UFBX_MATERIAL_PBR_MAP_COUNT; i++) {
+					const char *str = ufbxt_pbr_map_name((ufbx_material_pbr_map)i);
+					if (!strcmp(dots[1], str)) {
+						name = (ufbx_material_pbr_map)i;
+						break;
+					}
+				}
+				if (name == (ufbx_material_pbr_map)UFBX_MATERIAL_PBR_MAP_COUNT) {
+					fprintf(stderr, "%s:%d: Unknown PBR material map '%s' in '%s'\n", filename, line, dots[1], tokens[0]);
+					ok = false;
+				} else {
+					map = &material->pbr.maps[name];
+				}
+			} else {
+				ufbxt_assert(0 && "Unhandled branch");
+			}
+
+			// Errors reported above, but set ok to false just to be sure..
+			if (!map) {
+				ok = false;
+				continue;
+			}
+
+			if (!strcmp(dots[2], "texture")) {
+				if (map->texture) {
+					if (strcmp(map->texture->relative_filename.data, tokens[1]) != 0) {
+						fprintf(stderr, "%s:%d: Material '%s' %s.%s is different: got '%s', expected '%s'\n", filename, line,
+							material->name.data, dots[0], dots[1], map->texture->relative_filename.data, tokens[1]);
+						ok = false;
+					}
+				} else {
+					fprintf(stderr, "%s:%d: Material '%s' %s.%s missing texture, expected '%s'\n", filename, line,
+						material->name.data, dots[0], dots[1], tokens[1]);
+					ok = false;
+				}
+			} else {
+				size_t tok_start = 1;
+				bool implicit = false;
+				for (;;) {
+					const char *tok = tokens[tok_start];
+					if (!strcmp(tok, "implicit")) {
+						implicit = true;
+					} else {
+						break;
+					}
+					tok_start++;
+				}
+
+				double ref[4];
+				size_t num_ref = 0;
+				for (; num_ref < 4; num_ref++) {
+					const char *tok = tokens[tok_start + num_ref];
+					if (!*tok) break;
+
+					char *end = NULL;
+					ref[num_ref] = strtod(tok, &end);
+					if (!end || *end != '\0') {
+						fprintf(stderr, "%s:%d: Bad number in '%s': '%s'\n", filename, line, tokens[0], tok);
+						ok = false;
+						num_ref = 0;
+						break;
+					}
+				}
+
+				if (num_ref == 0) continue;
+
+				if (!implicit && !map->has_value) {
+					fprintf(stderr, "%s:%d: Material '%s' %s.%s not defined in material\n", filename, line,
+						material->name.data, dots[0], dots[1]);
+					ok = false;
+					continue;
+				} else if (implicit && map->has_value) {
+					fprintf(stderr, "%s:%d: Material '%s' %s.%s defined in material, expected implicit\n", filename, line,
+						material->name.data, dots[0], dots[1]);
+					ok = false;
+					continue;
+				}
+
+				if (!implicit && (size_t)map->value_components != num_ref) {
+					fprintf(stderr, "%s:%d: Material '%s' %s.%s has wrong number of components: got %zu, expected %zu\n", filename, line,
+						material->name.data, dots[0], dots[1], (size_t)map->value_components, num_ref);
+					ok = false;
+					continue;
+				}
+
+				char mat_str[128];
+				char ref_str[128];
+				size_t mat_pos = 0;
+				size_t ref_pos = 0;
+
+				bool equal = true;
+				for (size_t i = 0; i < num_ref; i++) {
+					double mat_value = map->value_vec4.v[i];
+					double ref_value = ref[i];
+					double err = fabs(mat_value - ref_value);
+					if (err > 0.002) {
+						equal = false;
+					}
+
+					err_sum += err;
+					if (err > err_max) err_max = err;
+					err_num += 1;
+
+					if (i > 0) {
+						mat_pos += (size_t)snprintf(mat_str + mat_pos, sizeof(mat_str) - mat_pos, ", ");
+						ref_pos += (size_t)snprintf(ref_str + ref_pos, sizeof(ref_str) - ref_pos, ", ");
+					}
+
+					mat_pos += (size_t)snprintf(mat_str + mat_pos, sizeof(mat_str) - mat_pos, "%.3f", mat_value);
+					ref_pos += (size_t)snprintf(ref_str + ref_pos, sizeof(ref_str) - ref_pos, "%.3f", ref_value);
+				}
+
+				if (!equal) {
+					fprintf(stderr, "%s:%d: Material '%s' %s.%s has wrong value: got (%s), expected (%s)\n", filename, line,
+						material->name.data, dots[0], dots[1], mat_str, ref_str);
+					ok = false;
+				}
+			}
+
+		} else if (!strcmp(dots[0], "features")) {
+			ufbx_material_feature name = (ufbx_material_feature)UFBX_MATERIAL_FEATURE_COUNT;
+			for (size_t i = 0; i < UFBX_MATERIAL_FEATURE_COUNT; i++) {
+				const char *str = ufbxt_material_feature_name((ufbx_material_feature)i);
+				if (!strcmp(dots[1], str)) {
+					name = (ufbx_material_feature)i;
+					break;
+				}
+			}
+			if (name == (ufbx_material_feature)UFBX_MATERIAL_FEATURE_COUNT) {
+				fprintf(stderr, "%s:%d: Unknown material feature '%s' in '%s'\n", filename, line, dots[1], tokens[0]);
+				ok = false;
+			}
+
+			ufbx_material_feature_info *feature = &material->features.features[name];
+
+			char *end = NULL;
+			long enabled = strtol(tokens[1], &end, 10);
+			if (!end || *end != '\0') {
+				fprintf(stderr, "%s:%d: Bad value in '%s': '%s'\n", filename, line, tokens[0], tokens[1]);
+				ok = false;
+				continue;
+			}
+
+			if (enabled != (long)feature->enabled) {
+				fprintf(stderr, "%s:%d: Material '%s' features.%s mismatch: got %ld, expected %ld\n", filename, line,
+					material->name.data, dots[1], (long)feature->enabled, enabled);
+				ok = false;
+				continue;
+			}
+		} else if (!strcmp(dots[0], "shader_type")) {
+			ufbx_shader_type name = (ufbx_shader_type)UFBX_SHADER_TYPE_COUNT;
+			for (size_t i = 0; i < UFBX_SHADER_TYPE_COUNT; i++) {
+				const char *str = ufbxt_shader_type_name((ufbx_shader_type)i);
+				if (!strcmp(tokens[1], str)) {
+					name = (ufbx_shader_type)i;
+					break;
+				}
+			}
+			if (name == (ufbx_shader_type)UFBX_SHADER_TYPE_COUNT) {
+				fprintf(stderr, "%s:%d: Unknown shader type '%s' in '%s'\n", filename, line, tokens[1], tokens[0]);
+				ok = false;
+			}
+
+			if (material->shader_type != name) {
+				const char *mat_name = ufbxt_shader_type_name(material->shader_type);
+				fprintf(stderr, "%s:%d: Material '%s' shader type mismatch: got '%s', expected '%s'\n", filename, line,
+					material->name.data, mat_name, tokens[1]);
+			}
+		} else {
+			fprintf(stderr, "%s:%d: Invalid token '%s'\n", filename, line, tokens[0]);
+			ok = false;
+		}
+	}
+
+	if (ok) {
+		double avg = err_num > 0 ? err_sum / (double)err_num : 0.0;
+		printf("Checked %zu materials, %zu properties (error avg %.3g, max %.3g, %zu tests)\n", num_materials, num_props, avg, err_max, err_num);
+	}
+
+	return ok;
+}
+
+#endif

--- a/test/test_obj.h
+++ b/test/test_obj.h
@@ -474,7 +474,7 @@ UFBXT_FILE_TEST(synthetic_simple_materials)
 		ufbxt_assert_close_vec3(err, mat->fbx.specular_color.value_vec3, ks);
 		ufbxt_assert_close_vec3(err, mat->fbx.emission_color.value_vec3, ke);
 		ufbxt_assert_close_real(err, mat->fbx.specular_exponent.value_real, ns);
-		ufbxt_assert_close_real(err, mat->fbx.transparency_factor.value_real, d);
+		ufbxt_assert_close_real(err, mat->fbx.transparency_factor.value_real, 1.0f - d);
 		ufbxt_assert(mat->fbx.ambient_factor.value_real == 1.0f);
 		ufbxt_assert(mat->fbx.diffuse_factor.value_real == 1.0f);
 		ufbxt_assert(mat->fbx.specular_factor.value_real == 1.0f);

--- a/ufbx.c
+++ b/ufbx.c
@@ -658,7 +658,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 2, 2)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 2, 3)
 const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);

--- a/ufbx.c
+++ b/ufbx.c
@@ -1,7 +1,11 @@
-#include "ufbx.h"
-
 #ifndef UFBX_UFBX_C_INCLUDED
 #define UFBX_UFBX_C_INCLUDED
+
+#if defined(UFBX_HEADER_PATH)
+	#include UFBX_HEADER_PATH
+#else
+	#include "ufbx.h"
+#endif
 
 // -- User configuration
 

--- a/ufbx.c
+++ b/ufbx.c
@@ -1,7 +1,7 @@
 #include "ufbx.h"
 
-#ifndef UFBX_UFBX_C_INLCUDED
-#define UFBX_UFBX_C_INLCUDED
+#ifndef UFBX_UFBX_C_INCLUDED
+#define UFBX_UFBX_C_INCLUDED
 
 // -- User configuration
 
@@ -1323,11 +1323,11 @@ typedef struct {
 //   dist.long_sym[]         N 0 0 0 I  // Long N bit code (huff+extra bits) for distance index I
 //   dist.long_sym[]         N 1 0 0 1  // Unused symbol 30-31 or invalid distance code
 //
-//   code_length.fast_sym[]  N 0 0 1 B  // Short N bit code (huff only, extra handled explcitly) for symbol bit count B
+//   code_length.fast_sym[]  N 0 0 1 B  // Short N bit code (huff only, extra handled explicitly) for symbol bit count B
 //   code_length.fast_sym[]  M 0 0 0 X  // Long code at `dist.long_sym[X*2 + ((bits>>FAST_BITS) & M)]`
 //   code_length.fast_sym[]  0 0 0 0 R  // Extra long code with prefix R, use `code_length.sorted_to_sym[]` to resolve (*1)
 //
-//   code_length.long_sym[]  N 0 0 0 B  // Long N bit code (huff only, extra handled explcitly) for symbol bit count B
+//   code_length.long_sym[]  N 0 0 0 B  // Long N bit code (huff only, extra handled explicitly) for symbol bit count B
 //
 // (*1) Never necessary if `fast_bits >= 10` due to `long_sym[]` covering all possible codes,
 //
@@ -1417,7 +1417,7 @@ ufbxi_bit_chunk_refill(ufbxi_bit_stream *s, const char *ptr)
 		size_t to_read = ufbxi_min_sz(s->input_left, s->buffer_size - left);
 		if (to_read > 0) {
 			size_t num_read = s->read_fn(s->read_user, s->buffer + left, to_read);
-			// TOOD: IO error, should unify with (currently broken) cancel logic
+			// TODO: IO error, should unify with (currently broken) cancel logic
 			if (num_read > to_read) num_read = 0;
 			ufbxi_dev_assert(s->input_left >= num_read);
 			s->input_left -= num_read;
@@ -2633,7 +2633,7 @@ static ufbxi_noinline int ufbxi_vsnprintf(char *buf, size_t buf_size, const char
 	if ((size_t)result >= buf_size - 1) result = (int)buf_size - 1;
 
 	// HACK: On some MSYS/MinGW implementations `vsnprintf` is broken and does
-	// not write the null terminator on trunctation, it's always safe to do so
+	// not write the null terminator on truncation, it's always safe to do so
 	// let's just do it unconditionally here...
 	buf[result] = '\0';
 
@@ -2848,7 +2848,7 @@ static ufbxi_forceinline bool ufbxi_does_overflow(size_t total, size_t a, size_t
 
 static ufbxi_noinline void *ufbxi_alloc_size(ufbxi_allocator *ator, size_t size, size_t n)
 {
-	// Always succeed with an emtpy non-NULL buffer for empty allocations
+	// Always succeed with an empty non-NULL buffer for empty allocations
 	ufbx_assert(size > 0);
 	if (n == 0) return (void*)ufbxi_zero_size_buffer;
 
@@ -3207,7 +3207,7 @@ static ufbxi_noinline void *ufbxi_push_size_new_block(ufbxi_buf *b, size_t size)
 
 static ufbxi_noinline void *ufbxi_push_size(ufbxi_buf *b, size_t size, size_t n)
 {
-	// Always succeed with an emtpy non-NULL buffer for empty allocations
+	// Always succeed with an empty non-NULL buffer for empty allocations
 	ufbx_assert(size > 0);
 	if (n == 0) return (void*)ufbxi_zero_size_buffer;
 
@@ -3259,7 +3259,7 @@ static ufbxi_noinline void *ufbxi_push_size(ufbxi_buf *b, size_t size, size_t n)
 
 static ufbxi_forceinline void *ufbxi_push_size_fast(ufbxi_buf *b, size_t size, size_t n)
 {
-	// Always succeed with an emtpy non-NULL buffer for empty allocations
+	// Always succeed with an empty non-NULL buffer for empty allocations
 	ufbxi_regression_assert(size > 0);
 	ufbxi_regression_assert(n > 0);
 
@@ -3276,7 +3276,7 @@ static ufbxi_forceinline void *ufbxi_push_size_fast(ufbxi_buf *b, size_t size, s
 
 	b->num_items += n;
 
-	// Homogenous arrays should always be aligned
+	// Homogeneous arrays should always be aligned
 	size_t pos = b->pos;
 	ufbxi_regression_assert((pos & ufbxi_size_align_mask(size)) == 0);
 
@@ -3299,7 +3299,7 @@ static ufbxi_forceinline void *ufbxi_push_size_zero(ufbxi_buf *b, size_t size, s
 
 ufbxi_nodiscard static ufbxi_forceinline void *ufbxi_push_size_copy(ufbxi_buf *b, size_t size, size_t n, const void *data)
 {
-	// Always succeed with an emtpy non-NULL buffer for empty allocations, even if `data == NULL`
+	// Always succeed with an empty non-NULL buffer for empty allocations, even if `data == NULL`
 	ufbx_assert(size > 0);
 	if (n == 0) return (void*)ufbxi_zero_size_buffer;
 
@@ -5141,7 +5141,7 @@ typedef struct {
 } ufbxi_value_array;
 
 struct ufbxi_node {
-	const char *name;      // < Name of the node (pooled, comapre with == to ufbxi_* strings)
+	const char *name;      // < Name of the node (pooled, compare with == to ufbxi_* strings)
 	uint32_t num_children; // < Number of child nodes
 	uint8_t name_len;      // < Length of `name` in bytes
 
@@ -10787,7 +10787,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_vertex_element(ufbxi_contex
 
 	// Data array is always used as-is, if empty set the data to a global
 	// zero buffer so invalid zero index can point to some valid data.
-	// The zero data is offset by 4 elements to accomodate for invalid index (-1)
+	// The zero data is offset by 4 elements to accommodate for invalid index (-1)
 	if (num_elems > 0) {
 		*p_dst_data = (ufbx_real*)data->data;
 	} else {
@@ -13023,7 +13023,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_take_prop_channel(ufbxi_con
 			}
 		}
 
-		// Find 1-3 channel nodes thast contain a `Key:` node
+		// Find 1-3 channel nodes that contain a `Key:` node
 		ufbxi_node *channel_nodes[3] = { 0 };
 		const char *channel_names[3] = { 0 };
 		size_t num_channel_nodes = 0;
@@ -15658,7 +15658,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_add_connections_to_elements(ufbx
 					prop->flags = (ufbx_prop_flags)((uint32_t)prop->flags | flags);
 				} else {
 					// Animated property that is not in the element property list
-					// Copy the preceeding properties to the stack, then push a
+					// Copy the preceding properties to the stack, then push a
 					// synthetic property for the animated property.
 					ufbxi_check(ufbxi_push_copy(&uc->tmp_stack, ufbx_prop, ufbxi_to_size(prop - copy_start), copy_start));
 					copy_start = prop;
@@ -15742,7 +15742,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_linearize_nodes(ufbxi_context *u
 		ufbx_node *node = *p_node;
 
 		// Pre-6000 files don't have any explicit root connections so they must always
-		// be connected to ther root..
+		// be connected to the root..
 		if (node->parent == NULL && !(uc->opts.allow_nodes_out_of_root && uc->version >= 6000)) {
 			if (node != uc->scene.root_node) {
 				node->parent = uc->scene.root_node;
@@ -17669,7 +17669,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_fetch_file_textures(ufbxi_contex
 			// Complex: Process all dependencies first
 			states[texture->typed_id] = UFBXI_FILE_TEXTURE_FETCH_STARTED;
 
-			// Push self first so we can return after processing depenencies
+			// Push self first so we can return after processing dependencies
 			ufbxi_check(ufbxi_push_copy(&uc->tmp_stack, ufbx_texture*, 1, &texture));
 			num_stack_textures++;
 
@@ -20018,7 +20018,7 @@ typedef struct {
 	uint32_t start_time;
 	uint32_t end_time;
 	uint32_t current_time;
-	uint32_t conescutive_fails;
+	uint32_t consecutive_fails;
 	bool try_load;
 } ufbxi_cache_tmp_channel;
 
@@ -20549,7 +20549,7 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_cache_load_frame_files(ufbxi_cac
 			// Find the first `time >= lowest_time` value that has data in some channel
 			uint32_t time = UINT32_MAX;
 			ufbxi_for(ufbxi_cache_tmp_channel, chan, cc->channels, cc->num_channels) {
-				if (!chan->try_load || chan->conescutive_fails > 10) continue;
+				if (!chan->try_load || chan->consecutive_fails > 10) continue;
 				uint32_t sample_rate = chan->sample_rate ? chan->sample_rate : cc->xml_ticks_per_frame;
 				if (chan->current_time < lowest_time) {
 					uint32_t delta = (lowest_time - chan->current_time - 1) / sample_rate;
@@ -20581,7 +20581,7 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_cache_load_frame_files(ufbxi_cac
 			// Update channel status
 			ufbxi_for(ufbxi_cache_tmp_channel, chan, cc->channels, cc->num_channels) {
 				if (chan->current_time == time) {
-					chan->conescutive_fails = found ? 0 : chan->conescutive_fails + 1;
+					chan->consecutive_fails = found ? 0 : chan->consecutive_fails + 1;
 				}
 			}
 
@@ -21791,7 +21791,7 @@ static ufbxi_noinline void ufbxi_evaluate_props(const ufbx_anim *anim, const ufb
 		if (!ufbxi_anim_layer_might_contain_id(layer, element_id)) continue;
 
 		// Find the weight for the current layer
-		// TODO: Should this be searched from multipler layers?
+		// TODO: Should this be searched from multiple layers?
 		// TODO: Use weight from layer_desc
 		ufbx_real weight = layer->weight;
 		if (layer->weight_is_animated && layer->blended) {
@@ -23272,7 +23272,7 @@ ufbxi_noinline static uint32_t ufbxi_triangulate_ngon(ufbxi_ngon_context *nc, ui
 	uint32_t *edges = indices + num_indices - face.num_indices * 2;
 
 	// Initialize `edges` to be a connectivity structure where:
-	//  `edges[2*i + 0]` is the prevous vertex of `i`
+	//  `edges[2*i + 0]` is the previous vertex of `i`
 	//  `edges[2*i + 1]` is the next vertex of `i`
 	// When clipped we mark indices with the high bit (0x80000000)
 	for (uint32_t i = 0; i < face.num_indices; i++) {

--- a/ufbx.c
+++ b/ufbx.c
@@ -16314,6 +16314,8 @@ static const ufbxi_shader_mapping ufbxi_osl_standard_shader_pbr_mapping[] = {
 	{ UFBX_MATERIAL_PBR_COAT_ANISOTROPY, 0, 0, ufbxi_mat_string("coat_anisotropy") },
 	{ UFBX_MATERIAL_PBR_COAT_ROTATION, 0, 0, ufbxi_mat_string("coat_rotation") },
 	{ UFBX_MATERIAL_PBR_COAT_NORMAL, 0, 0, ufbxi_mat_string("coat_normal") },
+	{ UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("coat_affect_color") },
+	{ UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_ROUGHNESS, 0, 0, ufbxi_mat_string("coat_affect_roughness") },
 	{ UFBX_MATERIAL_PBR_THIN_FILM_THICKNESS, 0, 0, ufbxi_mat_string("thin_film_thickness") },
 	{ UFBX_MATERIAL_PBR_THIN_FILM_IOR, 0, 0, ufbxi_mat_string("thin_film_IOR") },
 	{ UFBX_MATERIAL_PBR_EMISSION_FACTOR, 0, 0, ufbxi_mat_string("emission") },

--- a/ufbx.c
+++ b/ufbx.c
@@ -961,7 +961,7 @@ static ufbxi_noinline void ufbxi_stable_sort(size_t stride, size_t linear_size, 
 
 #if !defined(UFBX_STANDARD_C) && UFBXI_MSC_VER >= 1920 && defined(_M_X64) && !defined(__clang__)
 	ufbxi_extern_c extern unsigned __int64 __cdecl _udiv128(unsigned __int64  highdividend,
-		unsigned __int64 lowdividend, unsigned __int64 divisor, unsigned __int64* remainder);
+		unsigned __int64 lowdividend, unsigned __int64 divisor, unsigned __int64 *remainder);
 	#define ufbxi_div128(a_hi, a_lo, b, p_rem) (_udiv128((a_hi), (a_lo), (b), (p_rem)))
 #elif !defined(UFBX_STANDARD_C) && (defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(_M_X64))
 	static ufbxi_forceinline uint64_t ufbxi_div128(uint64_t a_hi, uint64_t a_lo, uint64_t b, uint64_t *p_rem) {
@@ -1552,7 +1552,7 @@ ufbxi_bit_refill(uint64_t *p_bits, size_t *p_left, const char **p_data, ufbxi_bi
 		m_bits |= m_refill_bits << m_left; \
 		m_data += (63 - m_left) >> 3; \
 		m_left |= 56; \
-	} while(0)
+	} while (0)
 
 static ufbxi_noinline int
 ufbxi_bit_copy_bytes(void *dst, ufbxi_bit_stream *s, size_t len)
@@ -24396,10 +24396,10 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_subdivide_mesh_level(ufbxi_subdi
 	memset(&result->vertex_color, 0, sizeof(result->vertex_color));
 
 	result->uv_sets.data = ufbxi_push_copy(&sc->result, ufbx_uv_set, result->uv_sets.count, result->uv_sets.data);
-	ufbxi_check_err(&sc->error,	result->uv_sets.data);
+	ufbxi_check_err(&sc->error, result->uv_sets.data);
 
 	result->color_sets.data = ufbxi_push_copy(&sc->result, ufbx_color_set, result->color_sets.count, result->color_sets.data);
-	ufbxi_check_err(&sc->error,	result->color_sets.data);
+	ufbxi_check_err(&sc->error, result->color_sets.data);
 
 	ufbxi_for_list(ufbx_uv_set, set, result->uv_sets) {
 		ufbxi_check_err(&sc->error, ufbxi_subdivide_attrib(sc, (ufbx_vertex_attrib*)&set->vertex_uv, sc->opts.uv_boundary, true));

--- a/ufbx.c
+++ b/ufbx.c
@@ -16142,12 +16142,14 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_sort_blend_keyframes(ufbxi_conte
 
 typedef void (*ufbxi_mat_transform_fn)(ufbx_vec4 *a);
 
+static void ufbxi_mat_transform_invert_x(ufbx_vec4 *v) { v->x = 1.0f - v->x; }
 static void ufbxi_mat_transform_unknown_shininess(ufbx_vec4 *v) { if (v->x >= 0.0f) v->x = (ufbx_real)(1.0f - ufbx_sqrt(v->x) * (ufbx_real)0.1); if (!(v->x >= 0.0f)) v->x = 0.0f; }
 static void ufbxi_mat_transform_blender_opacity(ufbx_vec4 *v) { v->x = 1.0f - v->x; }
 static void ufbxi_mat_transform_blender_shininess(ufbx_vec4 *v) { if (v->x >= 0.0f) v->x = (ufbx_real)(1.0f - ufbx_sqrt(v->x) * (ufbx_real)0.1); if (!(v->x >= 0.0f)) v->x = 0.0f; }
 
 typedef enum {
 	UFBXI_MAT_TRANSFORM_IDENTITY,
+	UFBXI_MAT_TRANSFORM_INVERT_X,
 	UFBXI_MAT_TRANSFORM_UNKNOWN_SHININESS,
 	UFBXI_MAT_TRANSFORM_BLENDER_OPACITY,
 	UFBXI_MAT_TRANSFORM_BLENDER_SHININESS,
@@ -16173,10 +16175,13 @@ typedef enum {
 
 static const ufbxi_mat_transform_fn ufbxi_mat_transform_fns[] = {
 	NULL,
+	&ufbxi_mat_transform_invert_x,
 	&ufbxi_mat_transform_unknown_shininess,
 	&ufbxi_mat_transform_blender_opacity,
 	&ufbxi_mat_transform_blender_shininess,
 };
+
+ufbx_static_assert(transform_count, ufbxi_arraycount(ufbxi_mat_transform_fns) == UFBXI_MAT_TRANSFORM_COUNT);
 
 typedef struct {
 	uint8_t index;     // < `ufbx_material_(fbx|pbr)_map`
@@ -16197,8 +16202,6 @@ typedef struct {
 	ufbx_string texture_enabled_prefix;
 	ufbx_string texture_enabled_suffix;
 } ufbxi_shader_mapping_list;
-
-ufbx_static_assert(transform_count, ufbxi_arraycount(ufbxi_mat_transform_fns) == UFBXI_MAT_TRANSFORM_COUNT);
 
 #define ufbxi_mat_string(str) sizeof(str) - 1, str
 
@@ -16239,7 +16242,7 @@ static const ufbxi_shader_mapping ufbxi_obj_fbx_mapping[] = {
 	{ UFBX_MATERIAL_FBX_SPECULAR_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1|UFBXI_SHADER_MAPPING_WIDEN_TO_RGB, 0, ufbxi_mat_string("Ks") },
 	{ UFBX_MATERIAL_FBX_EMISSION_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1|UFBXI_SHADER_MAPPING_WIDEN_TO_RGB, 0, ufbxi_mat_string("Ke") },
 	{ UFBX_MATERIAL_FBX_SPECULAR_EXPONENT, 0, 0, ufbxi_mat_string("Ns") },
-	{ UFBX_MATERIAL_FBX_TRANSPARENCY_FACTOR, 0, 0, ufbxi_mat_string("d") },
+	{ UFBX_MATERIAL_FBX_TRANSPARENCY_FACTOR, 0, UFBXI_MAT_TRANSFORM_INVERT_X, ufbxi_mat_string("d") },
 	{ UFBX_MATERIAL_FBX_NORMAL_MAP, 0, 0, ufbxi_mat_string("norm") },
 	{ UFBX_MATERIAL_FBX_DISPLACEMENT, 0, 0, ufbxi_mat_string("disp") },
 	{ UFBX_MATERIAL_FBX_BUMP, 0, 0, ufbxi_mat_string("bump") },

--- a/ufbx.h
+++ b/ufbx.h
@@ -1040,6 +1040,8 @@ struct ufbx_mesh {
 		ufbx_node_list instances;
 	}; };
 
+	int abi_break_test;
+
 	// Number of "logical" vertices that would be treated as a single point,
 	// one vertex may be split to multiple indices for split attributes, eg. UVs
 	size_t num_vertices;  // < Number of logical "vertex" points

--- a/ufbx.h
+++ b/ufbx.h
@@ -1040,8 +1040,6 @@ struct ufbx_mesh {
 		ufbx_node_list instances;
 	}; };
 
-	int abi_break_test;
-
 	// Number of "logical" vertices that would be treated as a single point,
 	// one vertex may be split to multiple indices for split attributes, eg. UVs
 	size_t num_vertices;  // < Number of logical "vertex" points

--- a/ufbx.h
+++ b/ufbx.h
@@ -161,7 +161,7 @@ typedef double ufbx_real;
 #define ufbx_version_minor(version) ((uint32_t)(version)/1000u%1000u)
 #define ufbx_version_patch(version) ((uint32_t)(version)%1000u)
 
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 2, 2)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 2, 3)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types

--- a/ufbx.h
+++ b/ufbx.h
@@ -1,5 +1,5 @@
-#ifndef UFBX_UFBX_H_INLCUDED
-#define UFBX_UFBX_H_INLCUDED
+#ifndef UFBX_UFBX_H_INCLUDED
+#define UFBX_UFBX_H_INCLUDED
 
 // -- User configuration
 
@@ -440,7 +440,7 @@ typedef struct ufbx_scene ufbx_scene;
 
 // Element is the lowest level representation of the FBX file in ufbx.
 // An element contains type, id, name, and properties (see `ufbx_props` above)
-// Elements may be connected to each other aribtrarily via `ufbx_connection`
+// Elements may be connected to each other arbitrarily via `ufbx_connection`
 
 typedef struct ufbx_element ufbx_element;
 
@@ -774,7 +774,7 @@ struct ufbx_node {
 	// See `adjust_pre_rotation`, `adjust_pre_scale`, `adjust_post_rotation`.
 	bool has_adjust_transform;
 
-	// True if this node is node is a syntehtic geometry transform helper.
+	// True if this node is node is a synthetic geometry transform helper.
 	// See `UFBX_GEOMETRY_TRANSFORM_HANDLING_HELPER_NODES`.
 	bool is_geometry_transform_helper;
 
@@ -1521,7 +1521,7 @@ struct ufbx_nurbs_curve {
 	ufbx_nurbs_basis basis;
 
 	// Linear array of control points
-	// NOTE: The control points are _not_ homogenous, meaning you have to multiply
+	// NOTE: The control points are _not_ homogeneous, meaning you have to multiply
 	// them by `w` before evaluating the surface.
 	ufbx_vec4_list control_points;
 };
@@ -1545,7 +1545,7 @@ struct ufbx_nurbs_surface {
 
 	// 2D array of control points.
 	// Memory layout: `V * num_control_points_u + U`
-	// NOTE: The control points are _not_ homogenous, meaning you have to multiply
+	// NOTE: The control points are _not_ homogeneous, meaning you have to multiply
 	// them by `w` before evaluating the surface.
 	ufbx_vec4_list control_points;
 
@@ -2891,7 +2891,7 @@ struct ufbx_selection_set {
 		uint32_t typed_id;
 	}; };
 
-	// Included nodes and geomtery features
+	// Included nodes and geometry features
 	ufbx_selection_node_list nodes;
 };
 
@@ -3594,7 +3594,7 @@ typedef struct ufbx_error_frame {
 // Error causes (and `UFBX_ERROR_NONE` for no error).
 typedef enum ufbx_error_type UFBX_ENUM_REPR {
 
-	// No error, operation has been performed succesfully.
+	// No error, operation has been performed successfully.
 	UFBX_ERROR_NONE,
 
 	// Unspecified error, most likely caused by an invalid FBX file or a file


### PR DESCRIPTION
Add support for testing materials in dataset files, inspired by the material diffing in [Magnum](https://twitter.com/czmosra/status/1590798552124784640).

Dataset files can have adjacent `file.mat` files that have a description of the expected materials in the file, for example:

```
material Red
    fbx.ambient_color 0.1 0.1 0.1
    fbx.diffuse_color 1 0 0
    pbr.roughness 0.5
```