### PR TITLE
Fix LTO ABI compatability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,8 @@ jobs:
         run: |
           g++ -Wall -Wextra -Werror -Wno-unused-function -pthread -std=c++11 -DUFBX_STANDARD_C -x c++ ufbx.c test/threadcheck.cpp -lm -o build/threadcheck-cpp11
           build/threadcheck-cpp11 data/maya_cube_7500_binary.fbx 2
+      - name: Link C/C++ LTO
+        run: bash misc/lto_compatability.sh
       - name: Compress hashdumps
         if: ${{ always() && !cancelled() }}
         run: python3 misc/hash_diff.py compress build/hashdumps -o build/hashdump_ci_exotic.txt.gz

--- a/misc/lto_compatability.sh
+++ b/misc/lto_compatability.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -u
+mkdir -p build/lto
+
+CFLAGS="-Wall -Wextra -Werror -Wlto-type-mismatch -Og"
+
+# Compile all objects
+printf "Compiling sources\n"
+set -e
+(set -x; gcc $CFLAGS -c -flto ufbx.c -o build/lto/ufbx-c.o)
+(set -x; gcc $CFLAGS -c -flto misc/minimal_load.c -o build/lto/load-c.o)
+(set -x; g++ $CFLAGS -c -flto -x c++ ufbx.c -o build/lto/ufbx-cpp.o)
+(set -x; g++ $CFLAGS -c -flto -x c++ misc/minimal_load.c -o build/lto/load-cpp.o)
+set +e
+
+# Cross link all combinations
+RC=0
+printf "\nufbx C, load C\n"
+(set -x; gcc $CFLAGS -flto build/lto/ufbx-c.o   build/lto/load-c.o   -lm -o build/lto/lto-c-c) || RC=$?
+printf "\nufbx C, load C++\n"
+(set -x; g++ $CFLAGS -flto build/lto/ufbx-c.o   build/lto/load-cpp.o -lm -o build/lto/lto-c-cpp) || RC=$?
+printf "\nufbx C++, load C\n"
+(set -x; g++ $CFLAGS -flto build/lto/ufbx-cpp.o build/lto/load-c.o   -lm -o build/lto/lto-cpp-c) || RC=$?
+printf "\nufbx C++, load C++\n"
+(set -x; g++ $CFLAGS -flto build/lto/ufbx-cpp.o build/lto/load-cpp.o -lm -o build/lto/lto-cpp-cpp) || RC=$?
+
+exit $RC

--- a/misc/minimal_load.c
+++ b/misc/minimal_load.c
@@ -1,0 +1,13 @@
+#include "../ufbx.h"
+#include <stddef.h>
+#include <string.h>
+
+int main() {
+    ufbx_load_opts opts;
+    memset(&opts, 0, sizeof(opts));
+    opts.target_axes = ufbx_axes_right_handed_y_up;
+    ufbx_scene *scene = ufbx_load_file("test.fbx", &opts, NULL);
+    if (!scene) return 1;
+    ufbx_free_scene(scene);
+    return 0;
+}

--- a/ufbx.c
+++ b/ufbx.c
@@ -11546,14 +11546,14 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_mesh(ufbxi_context *uc, ufb
 			ufbxi_check(ufbxi_read_vertex_element(uc, mesh, n, (ufbx_vertex_attrib*)&mesh->vertex_crease,
 				ufbxi_VertexCrease, ufbxi_VertexCreaseIndex, 'r', 1));
 		} else if (n->name == ufbxi_LayerElementEdgeCrease) {
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByEdge) {
 				if (mesh->edge_crease.count) continue;
 				ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->edge_crease.data, &mesh->edge_crease.count, n, ufbxi_EdgeCrease, 'r', mesh->num_edges));
 			}
 		} else if (n->name == ufbxi_LayerElementSmoothing) {
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByEdge) {
 				if (mesh->edge_smoothing.count) continue;
@@ -11563,7 +11563,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_mesh(ufbxi_context *uc, ufb
 				ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->face_smoothing.data, &mesh->face_smoothing.count, n, ufbxi_Smoothing, 'b', mesh->num_faces));
 			}
 		} else if (n->name == ufbxi_LayerElementVisibility) {
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByEdge) {
 				if (mesh->edge_visibility.count) continue;
@@ -11571,7 +11571,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_mesh(ufbxi_context *uc, ufb
 			}
 		} else if (n->name == ufbxi_LayerElementMaterial) {
 			if (mesh->face_material.count) continue;
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByPolygon) {
 				ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->face_material.data, &mesh->face_material.count, n, ufbxi_Materials, 'i', mesh->num_faces));
@@ -11592,14 +11592,14 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_mesh(ufbxi_context *uc, ufb
 			}
 		} else if (n->name == ufbxi_LayerElementPolygonGroup) {
 			if (mesh->face_group.count) continue;
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByPolygon) {
 				ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->face_group.data, &mesh->face_group.count, n, ufbxi_PolygonGroup, 'i', mesh->num_faces));
 			}
 		} else if (n->name == ufbxi_LayerElementHole) {
 			if (mesh->face_group.count) continue;
-			const char *mapping;
+			const char *mapping = NULL;
 			ufbxi_check(ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping));
 			if (mapping == ufbxi_ByPolygon) {
 				ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->face_hole.data, &mesh->face_hole.count, n, ufbxi_Hole, 'b', mesh->num_faces));
@@ -11625,7 +11625,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_mesh(ufbxi_context *uc, ufb
 
 			if (prop_name.length > 0) {
 				ufbxi_check(ufbxi_push_string_place_str(&uc->string_pool, &prop_name, false));
-				const char *mapping;
+				const char *mapping = NULL;
 				if (ufbxi_find_val1(n, ufbxi_MappingInformationType, "c", (char**)&mapping)) {
 					ufbxi_value_array *arr = ufbxi_find_array(n, ufbxi_TextureId, 'i');
 
@@ -13591,7 +13591,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_read_legacy_mesh(ufbxi_context *
 
 	// Material indices
 	{
-		const char *mapping;
+		const char *mapping = NULL;
 		ufbxi_check(ufbxi_find_val1(node, ufbxi_MaterialAssignation, "C", (char**)&mapping));
 		if (mapping == ufbxi_ByPolygon) {
 			ufbxi_check(ufbxi_read_truncated_array(uc, &mesh->face_material.data, &mesh->face_material.count, node, ufbxi_Materials, 'i', mesh->num_faces));

--- a/ufbx.c
+++ b/ufbx.c
@@ -684,7 +684,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 5, 2)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 6, 0)
 const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);

--- a/ufbx.h
+++ b/ufbx.h
@@ -136,7 +136,10 @@
 	#define UFBX_LIST_TYPE(p_name, p_type) typedef struct p_name { p_type *data; size_t count; } p_name
 #endif
 
-#if UFBX_STDC >= 202311L || UFBX_CPP11
+// This cannot be enabled automatically if supported as the source file may be
+// compiled with a different compiler using different settings than the header
+// consumers, in practice it should work but it causes issues such as #70.
+#if (UFBX_STDC >= 202311L || UFBX_CPP11) && defined(UFBX_USE_EXPLICIT_ENUM)
 	#define UFBX_ENUM_REPR : int
 	#define UFBX_ENUM_FORCE_WIDTH(p_prefix)
 	#define UFBX_FLAG_REPR : int

--- a/ufbx.h
+++ b/ufbx.h
@@ -178,7 +178,7 @@
 #define ufbx_version_minor(version) ((uint32_t)(version)/1000u%1000u)
 #define ufbx_version_patch(version) ((uint32_t)(version)%1000u)
 
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 5, 2)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 6, 0)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types


### PR DESCRIPTION
Currently enums are defined differently depending on compilation environment, which causes issues when `ufbx.c` is compiled as C and whatever is using `ufbx.h` is compiled as C++, see #70 