### PR TITLE
Separate and downgrade coverage on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           path: build/hashes.txt
 
   ci_ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: ci_pre_hashes
     steps:
       - uses: actions/checkout@v3
@@ -53,10 +53,6 @@ jobs:
         run: python3 misc/run_tests.py tests stack readme threadcheck hashes --runner ci_linux
       - name: Verbose test info
         run: build/runner_clang_release_x64/runner -d data -v
-      - name: Generate coverage
-        run: LLVM_COV=llvm-cov-11 bash misc/generate_coverage.sh
-      - name: Upload coverage
-        run: bash <(curl -s https://codecov.io/bash) -f coverage.lcov -y .github/codecov.yml
       - name: Compress hashdumps
         if: ${{ always() && !cancelled() }}
         run: python3 misc/hash_diff.py compress build/hashdumps -o build/hashdump_ci_linux.txt.gz
@@ -115,6 +111,22 @@ jobs:
         with:
           name: hash-dumps
           path: build/hashdump_ci_macos.txt.gz
+
+  ci_coverage:
+    runs-on: ubuntu-20.04
+    needs: ci_pre_hashes
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install apt dependencies
+        run: sudo apt-get install -y gcc-multilib g++-multilib lcov llvm-11
+      - name: Generate coverage
+        run: LLVM_COV=llvm-cov-11 bash misc/generate_coverage.sh
+      - name: Upload coverage
+        run: bash <(curl -s https://codecov.io/bash) -f coverage.lcov -y .github/codecov.yml
 
   ci_picort:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ufbx [![CI](https://github.com/bqqbarbhg/ufbx/actions/workflows/ci.yml/badge.svg)](https://github.com/bqqbarbhg/ufbx/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/bqqbarbhg/ufbx/branch/master/graph/badge.svg)](https://codecov.io/gh/bqqbarbhg/ufbx)
+# ufbx [![CI](https://github.com/bqqbarbhg/ufbx/actions/workflows/ci.yml/badge.svg)](https://github.com/bqqbarbhg/ufbx/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/ufbx/ufbx/branch/master/graph/badge.svg)](https://codecov.io/gh/ufbx/ufbx)
 
 Single source file FBX file loader.
 

--- a/misc/generate_coverage.sh
+++ b/misc/generate_coverage.sh
@@ -2,6 +2,8 @@
 set -x
 set -e
 
+mkdir -p build
+
 LLVM_COV="${LLVM_COV:-llvm-cov}"
 LLVM_GCOV=$(realpath misc/llvm_gcov.sh)
 chmod +x misc/llvm_gcov.sh


### PR DESCRIPTION
Coverage is somewhat broken in Ubuntu 22.04, reporting ~15% instead of 95%