### PR TITLE
Evaluate assert argument in coverage

### DIFF
--- a/misc/generate_coverage.sh
+++ b/misc/generate_coverage.sh
@@ -8,7 +8,7 @@ LLVM_COV="${LLVM_COV:-llvm-cov}"
 LLVM_GCOV=$(realpath misc/llvm_gcov.sh)
 chmod +x misc/llvm_gcov.sh
 
-clang -lm -coverage -g -std=gnu99 -DNDEBUG -DUFBX_NO_ASSERT -DUFBX_DEV=1 -DUFBX_REGRESSION=1 -DUFBXT_THREADS=1 -pthread ufbx.c test/runner.c -o build/cov-runner
+clang -lm -coverage -g -std=gnu99 -DNDEBUG -DUFBX_VOID_ASSERT -DUFBX_DEV=1 -DUFBX_REGRESSION=1 -DUFBXT_THREADS=1 -pthread ufbx.c test/runner.c -o build/cov-runner
 build/cov-runner -d data
 $LLVM_COV gcov ufbx runner -b
 lcov --directory . --base-directory . --gcov-tool $LLVM_GCOV --rc lcov_branch_coverage=1 --capture -o coverage.lcov

--- a/ufbx.h
+++ b/ufbx.h
@@ -98,7 +98,7 @@
 	#if defined(UFBX_NO_ASSERT)
 		#define ufbx_assert(cond) (void)0
 	#elif defined(UFBX_VOID_ASSERT)
-		#define ufbx_assert(cond) (void)!(cond)
+		#define ufbx_assert(cond) (void)(!(cond))
 	#else
 		#include <assert.h>
 		#define ufbx_assert(cond) assert(cond)

--- a/ufbx.h
+++ b/ufbx.h
@@ -95,11 +95,13 @@
 #endif
 
 #ifndef ufbx_assert
-	#if !defined(UFBX_NO_ASSERT)
+	#if defined(UFBX_NO_ASSERT)
+		#define ufbx_assert(cond) (void)0
+	#elif defined(UFBX_VOID_ASSERT)
+		#define ufbx_assert(cond) (void)!(cond)
+	#else
 		#include <assert.h>
 		#define ufbx_assert(cond) assert(cond)
-	#else
-		#define ufbx_assert(cond) (void)0
 	#endif
 #endif
 


### PR DESCRIPTION
If unevaluated, partial coverage from assert-aware tests marks the lines partial.