### PR TITLE
Better stepped tangent handling for ufbx_bake_anim()

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following platforms are tested on CI and produce bit-exact results:
 ## Testing
 
 * Internal tests run on all platforms listed above
-  * 500 test cases / 541 FBX files
+  * 525 test cases / 563 FBX files
 * Fuzzed in multiple layers
   * Parsers (fbx binary/fbx ascii/deflate/xml/mcx/obj/mtl) fuzzed using AFL
   * Structured FBX binary/ascii fuzzing using AFL

--- a/data/maya_huge_stepped_tangents_7700_ascii.fbx
+++ b/data/maya_huge_stepped_tangents_7700_ascii.fbx
@@ -1,0 +1,487 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 24
+		Hour: 4
+		Minute: 54
+		Second: 19
+		Millisecond: 608
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_huge_stepped_tangents_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_huge_stepped_tangents_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "24/03/2024 02:54:19.606"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_huge_stepped_tangents_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "24/03/2024 02:54:19.606"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",0
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",0
+		P: "TimeSpanStop", "KTime", "Time", "",16627016880000000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 2545754467712, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 10
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceLambert" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Lambert"
+				P: "MultiLayer", "bool", "", "",0
+				P: "EmissiveColor", "Color", "", "A",0,0,0
+				P: "EmissiveFactor", "Number", "", "A",1
+				P: "AmbientColor", "Color", "", "A",0.2,0.2,0.2
+				P: "AmbientFactor", "Number", "", "A",1
+				P: "DiffuseColor", "Color", "", "A",0.8,0.8,0.8
+				P: "DiffuseFactor", "Number", "", "A",1
+				P: "Bump", "Vector3D", "Vector", "",0,0,0
+				P: "NormalMap", "Vector3D", "Vector", "",0,0,0
+				P: "BumpFactor", "double", "Number", "",1
+				P: "TransparentColor", "Color", "", "A",0,0,0
+				P: "TransparencyFactor", "Number", "", "A",0
+				P: "DisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "DisplacementFactor", "double", "Number", "",1
+				P: "VectorDisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "VectorDisplacementFactor", "double", "Number", "",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 1
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 2546536155296, "Geometry::", "Mesh" {
+		Vertices: *24 {
+			a: -0.5,-0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,-0.5,-0.5,-0.5,-0.5,0.5,-0.5,-0.5
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,1,3,-3,2,3,5,-5,4,5,7,-7,6,7,1,-1,1,7,5,-4,6,0,2,-5
+		} 
+		Edges: *12 {
+			a: 0,2,6,10,3,1,7,5,11,9,15,13
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementBinormal: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Binormals: *72 {
+				a: 0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,-0,1,0,-0,1,0,0,1,-0,-0,1,0,0,1,0,0,1,0,0,1,0,0,1,0
+			} 
+			BinormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+
+		}
+		LayerElementTangent: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Tangents: *72 {
+				a: 1,-0,-0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,-0,1,0,-0,1,0,-0,1,0,-0,0,0,-1,0,0,-1,0,-0,-1,0,0,-1,0,-0,1,0,-0,1,0,-0,1,0,-0,1
+			} 
+			TangentsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *28 {
+				a: 0.375,0,0.625,0,0.375,0.25,0.625,0.25,0.375,0.5,0.625,0.5,0.375,0.75,0.625,0.75,0.375,1,0.625,1,0.875,0,0.875,0.25,0.125,0,0.125,0.25
+			} 
+			UVIndex: *24 {
+				a: 0,1,3,2,2,3,5,4,4,5,7,6,6,7,9,8,1,10,11,3,12,0,2,13
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementBinormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementTangent"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 2543423404992, "Model::pCube1", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A+",10,0,0
+			P: "currentUVSet", "KString", "", "U", "map1"
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 2543868614304, "Material::lambert1", "" {
+		Version: 102
+		ShadingModel: "lambert"
+		MultiLayer: 0
+		Properties70:  {
+			P: "AmbientColor", "Color", "", "A",0,0,0
+			P: "DiffuseColor", "Color", "", "A",0.5,0.5,0.5
+			P: "DiffuseFactor", "Number", "", "A",0.800000011920929
+			P: "TransparencyFactor", "Number", "", "A",1
+			P: "Emissive", "Vector3D", "Vector", "",0,0,0
+			P: "Ambient", "Vector3D", "Vector", "",0,0,0
+			P: "Diffuse", "Vector3D", "Vector", "",0.400000005960464,0.400000005960464,0.400000005960464
+			P: "Opacity", "double", "Number", "",1
+		}
+	}
+	AnimationStack: 2546536433408, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStop", "KTime", "Time", "",16627016880000000
+			P: "ReferenceStop", "KTime", "Time", "",16627016880000000
+		}
+	}
+	AnimationCurve: 2546526287360, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *11 {
+			a: 0,461861580000,923723160000,4618615800000,9237231600000,46186158000000,92372316000000,461861580000000,923723160000000,4618615800000000,9237231600000000
+		} 
+		KeyValueFloat: *11 {
+			a: 0,1,2,3,4,5,6,7,8,9,10
+		} 
+		;KeyAttrFlags: Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantNext
+		KeyAttrFlags: *11 {
+			a: 2,258,2,258,2,258,2,258,2,258,258
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0.0375; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0.00375; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0.000375; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:3.75e-05; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0; RightAuto:0, NextLeftAuto:0
+		KeyAttrDataFloat: *44 {
+			a: 0,0,218434821,0,0,1025087898,218434821,0,0,0,218434821,0,0,997573263,218434821,0,0,0,218434821,0,0,969186214,218434821,0,0,0,218434821,0,0,941443410,218434821,0,0,0,218434821,0,0,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *11 {
+			a: 1,1,1,1,1,1,1,1,1,1,1
+		} 
+	}
+	AnimationCurveNode: 2546536433824, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",10
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 2546536434656, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 2546536434864, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationLayer: 2545828049952, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::pCube1, Model::RootNode
+	C: "OO",2543423404992,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",2545828049952,2546536433408
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",2546536433824,2545828049952
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",2546536434656,2545828049952
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",2546536434864,2545828049952
+	
+	;Geometry::, Model::pCube1
+	C: "OO",2546536155296,2543423404992
+	
+	;Material::lambert1, Model::pCube1
+	C: "OO",2543868614304,2543423404992
+	
+	;AnimCurveNode::T, Model::pCube1
+	C: "OP",2546536433824,2543423404992, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::pCube1
+	C: "OP",2546536434864,2543423404992, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::pCube1
+	C: "OP",2546536434656,2543423404992, "Lcl Scaling"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",2546526287360,2546536433824, "d|X"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 0,16627016880000000
+		ReferenceTime: 0,16627016880000000
+	}
+}

--- a/data/maya_keyframe_offset_7700_ascii.fbx
+++ b/data/maya_keyframe_offset_7700_ascii.fbx
@@ -1,0 +1,514 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 26
+		Hour: 20
+		Minute: 19
+		Second: 33
+		Millisecond: 121
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "26/03/2024 18:19:33.119"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "26/03/2024 18:19:33.119"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Top"
+		P: "TimeMode", "enum", "", "",6
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",0
+		P: "TimeSpanStop", "KTime", "Time", "",192442325000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 2059089188752, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 11
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceLambert" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Lambert"
+				P: "MultiLayer", "bool", "", "",0
+				P: "EmissiveColor", "Color", "", "A",0,0,0
+				P: "EmissiveFactor", "Number", "", "A",1
+				P: "AmbientColor", "Color", "", "A",0.2,0.2,0.2
+				P: "AmbientFactor", "Number", "", "A",1
+				P: "DiffuseColor", "Color", "", "A",0.8,0.8,0.8
+				P: "DiffuseFactor", "Number", "", "A",1
+				P: "Bump", "Vector3D", "Vector", "",0,0,0
+				P: "NormalMap", "Vector3D", "Vector", "",0,0,0
+				P: "BumpFactor", "double", "Number", "",1
+				P: "TransparentColor", "Color", "", "A",0,0,0
+				P: "TransparencyFactor", "Number", "", "A",0
+				P: "DisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "DisplacementFactor", "double", "Number", "",1
+				P: "VectorDisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "VectorDisplacementFactor", "double", "Number", "",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 2
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 2058377770208, "Geometry::", "Mesh" {
+		Vertices: *24 {
+			a: -0.5,-0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,-0.5,-0.5,-0.5,-0.5,0.5,-0.5,-0.5
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,1,3,-3,2,3,5,-5,4,5,7,-7,6,7,1,-1,1,7,5,-4,6,0,2,-5
+		} 
+		Edges: *12 {
+			a: 0,2,6,10,3,1,7,5,11,9,15,13
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementBinormal: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Binormals: *72 {
+				a: 0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,-0,1,0,-0,1,0,0,1,-0,-0,1,0,0,1,0,0,1,0,0,1,0,0,1,0
+			} 
+			BinormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+
+		}
+		LayerElementTangent: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Tangents: *72 {
+				a: 1,-0,-0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,-0,1,0,-0,1,0,-0,1,0,-0,0,0,-1,0,0,-1,0,-0,-1,0,0,-1,0,-0,1,0,-0,1,0,-0,1,0,-0,1
+			} 
+			TangentsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *28 {
+				a: 0.375,0,0.625,0,0.375,0.25,0.625,0.25,0.375,0.5,0.625,0.5,0.375,0.75,0.625,0.75,0.375,1,0.625,1,0.875,0,0.875,0.25,0.125,0,0.125,0.25
+			} 
+			UVIndex: *24 {
+				a: 0,1,3,2,2,3,5,4,4,5,7,6,6,7,9,8,1,10,11,3,12,0,2,13
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementBinormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementTangent"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 2057730445184, "Model::pCube1", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationPivot", "Vector3D", "Vector", "",0,-2,0
+			P: "ScalingPivot", "Vector3D", "Vector", "",0,-2,0
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A+",0,2,3
+			P: "Lcl Rotation", "Lcl Rotation", "", "A+",0,0,-90
+			P: "currentUVSet", "KString", "", "U", "map1"
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 2056899726640, "Material::lambert1", "" {
+		Version: 102
+		ShadingModel: "lambert"
+		MultiLayer: 0
+		Properties70:  {
+			P: "AmbientColor", "Color", "", "A",0,0,0
+			P: "DiffuseColor", "Color", "", "A",0.5,0.5,0.5
+			P: "DiffuseFactor", "Number", "", "A",0.800000011920929
+			P: "TransparencyFactor", "Number", "", "A",1
+			P: "Emissive", "Vector3D", "Vector", "",0,0,0
+			P: "Ambient", "Vector3D", "Vector", "",0,0,0
+			P: "Diffuse", "Vector3D", "Vector", "",0.400000005960464,0.400000005960464,0.400000005960464
+			P: "Opacity", "double", "Number", "",1
+		}
+	}
+	AnimationStack: 2056170412992, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStop", "KTime", "Time", "",70818775600
+			P: "ReferenceStop", "KTime", "Time", "",70818775600
+		}
+	}
+	AnimationCurve: 2058554754928, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *3 {
+			a: 0,6159116611,12316308800
+		} 
+		KeyValueFloat: *3 {
+			a: 0,1,3
+		} 
+		;KeyAttrFlags: Linear, Linear, Linear
+		KeyAttrFlags: *3 {
+			a: 1028,1028,1028
+		} 
+		;KeyAttrDataFloat: RightSlope:7.49883, NextLeftSlope:7.49883, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:15.0023, NextLeftSlope:15.0023, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *12 {
+			a: 1089468007,1089468007,218434821,0,1097861530,1097861530,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *3 {
+			a: 1,1,1
+		} 
+	}
+	AnimationCurve: 2058554761008, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *2 {
+			a: 0,12316308800
+		} 
+		KeyValueFloat: *2 {
+			a: 0,-90
+		} 
+		;KeyAttrFlags: Cubic|TangeantUser, Cubic|TangeantUser
+		KeyAttrFlags: *2 {
+			a: 1032,1032
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *8 {
+			a: 0,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *2 {
+			a: 1,1
+		} 
+	}
+	AnimationCurveNode: 2056170412160, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",2
+			P: "d|Z", "Number", "", "A",3
+		}
+	}
+	AnimationCurveNode: 2056170412368, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 2056170411536, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",-90
+		}
+	}
+	AnimationLayer: 2059085049952, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::pCube1, Model::RootNode
+	C: "OO",2057730445184,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",2059085049952,2056170412992
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",2056170412160,2059085049952
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",2056170412368,2059085049952
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",2056170411536,2059085049952
+	
+	;Geometry::, Model::pCube1
+	C: "OO",2058377770208,2057730445184
+	
+	;Material::lambert1, Model::pCube1
+	C: "OO",2056899726640,2057730445184
+	
+	;AnimCurveNode::T, Model::pCube1
+	C: "OP",2056170412160,2057730445184, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::pCube1
+	C: "OP",2056170411536,2057730445184, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::pCube1
+	C: "OP",2056170412368,2057730445184, "Lcl Scaling"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",2058554754928,2056170412160, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",2058554761008,2056170411536, "d|Z"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 0,70818775600
+		ReferenceTime: 0,70818775600
+	}
+}

--- a/data/maya_keyframe_offset_step_7700_ascii.fbx
+++ b/data/maya_keyframe_offset_step_7700_ascii.fbx
@@ -1,0 +1,514 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 26
+		Hour: 22
+		Minute: 45
+		Second: 44
+		Millisecond: 336
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_step_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_step_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "26/03/2024 20:45:44.335"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_keyframe_offset_step_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "26/03/2024 20:45:44.335"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",0
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",0
+		P: "TimeSpanStop", "KTime", "Time", "",192442325000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 2058566490112, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 11
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceLambert" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Lambert"
+				P: "MultiLayer", "bool", "", "",0
+				P: "EmissiveColor", "Color", "", "A",0,0,0
+				P: "EmissiveFactor", "Number", "", "A",1
+				P: "AmbientColor", "Color", "", "A",0.2,0.2,0.2
+				P: "AmbientFactor", "Number", "", "A",1
+				P: "DiffuseColor", "Color", "", "A",0.8,0.8,0.8
+				P: "DiffuseFactor", "Number", "", "A",1
+				P: "Bump", "Vector3D", "Vector", "",0,0,0
+				P: "NormalMap", "Vector3D", "Vector", "",0,0,0
+				P: "BumpFactor", "double", "Number", "",1
+				P: "TransparentColor", "Color", "", "A",0,0,0
+				P: "TransparencyFactor", "Number", "", "A",0
+				P: "DisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "DisplacementFactor", "double", "Number", "",1
+				P: "VectorDisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "VectorDisplacementFactor", "double", "Number", "",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 2
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 2058377913120, "Geometry::", "Mesh" {
+		Vertices: *24 {
+			a: -0.5,-0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,-0.5,-0.5,-0.5,-0.5,0.5,-0.5,-0.5
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,1,3,-3,2,3,5,-5,4,5,7,-7,6,7,1,-1,1,7,5,-4,6,0,2,-5
+		} 
+		Edges: *12 {
+			a: 0,2,6,10,3,1,7,5,11,9,15,13
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementBinormal: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Binormals: *72 {
+				a: 0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,-0,1,0,-0,1,0,0,1,-0,-0,1,0,0,1,0,0,1,0,0,1,0,0,1,0
+			} 
+			BinormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+
+		}
+		LayerElementTangent: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Tangents: *72 {
+				a: 1,-0,-0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,-0,1,0,-0,1,0,-0,1,0,-0,0,0,-1,0,0,-1,0,-0,-1,0,0,-1,0,-0,1,0,-0,1,0,-0,1,0,-0,1
+			} 
+			TangentsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *28 {
+				a: 0.375,0,0.625,0,0.375,0.25,0.625,0.25,0.375,0.5,0.625,0.5,0.375,0.75,0.625,0.75,0.375,1,0.625,1,0.875,0,0.875,0.25,0.125,0,0.125,0.25
+			} 
+			UVIndex: *24 {
+				a: 0,1,3,2,2,3,5,4,4,5,7,6,6,7,9,8,1,10,11,3,12,0,2,13
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementBinormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementTangent"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 2057730468384, "Model::pCube1", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationPivot", "Vector3D", "Vector", "",0,-2,0
+			P: "ScalingPivot", "Vector3D", "Vector", "",0,-2,0
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A+",0,2,0.999843774410248
+			P: "Lcl Rotation", "Lcl Rotation", "", "A+",0,0,-45
+			P: "currentUVSet", "KString", "", "U", "map1"
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 2056921590432, "Material::lambert1", "" {
+		Version: 102
+		ShadingModel: "lambert"
+		MultiLayer: 0
+		Properties70:  {
+			P: "AmbientColor", "Color", "", "A",0,0,0
+			P: "DiffuseColor", "Color", "", "A",0.5,0.5,0.5
+			P: "DiffuseFactor", "Number", "", "A",0.800000011920929
+			P: "TransparencyFactor", "Number", "", "A",1
+			P: "Emissive", "Vector3D", "Vector", "",0,0,0
+			P: "Ambient", "Vector3D", "Vector", "",0,0,0
+			P: "Diffuse", "Vector3D", "Vector", "",0.400000005960464,0.400000005960464,0.400000005960464
+			P: "Opacity", "double", "Number", "",1
+		}
+	}
+	AnimationStack: 2059091575920, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStop", "KTime", "Time", "",70818775600
+			P: "ReferenceStop", "KTime", "Time", "",70818775600
+		}
+	}
+	AnimationCurve: 2059081553280, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *3 {
+			a: 0,6159116611,12316308800
+		} 
+		KeyValueFloat: *3 {
+			a: 0,1,3
+		} 
+		;KeyAttrFlags: Linear, Linear, Linear
+		KeyAttrFlags: *3 {
+			a: 1028,1028,1028
+		} 
+		;KeyAttrDataFloat: RightSlope:7.49883, NextLeftSlope:7.49883, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:15.0023, NextLeftSlope:15.0023, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *12 {
+			a: 1089468007,1089468007,218434821,0,1097861530,1097861530,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *3 {
+			a: 1,1,1
+		} 
+	}
+	AnimationCurve: 2059081559520, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *3 {
+			a: 0,6158154400,12316308800
+		} 
+		KeyValueFloat: *3 {
+			a: 0,-45,-90
+		} 
+		;KeyAttrFlags: Constant|ConstantStandard, Cubic|TangeantUser|GenericBreak, Cubic|TangeantUser
+		KeyAttrFlags: *3 {
+			a: 2,3080,1032
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:-11.8697, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:-11.8697, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *12 {
+			a: 0,-1052906960,218434821,0,-1052906945,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *3 {
+			a: 1,1,1
+		} 
+	}
+	AnimationCurveNode: 2059091579664, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",2
+			P: "d|Z", "Number", "", "A",0.999843774410248
+		}
+	}
+	AnimationCurveNode: 2059091574880, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 2059091580080, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",-45
+		}
+	}
+	AnimationLayer: 2058551339248, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::pCube1, Model::RootNode
+	C: "OO",2057730468384,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",2058551339248,2059091575920
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",2059091579664,2058551339248
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",2059091574880,2058551339248
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",2059091580080,2058551339248
+	
+	;Geometry::, Model::pCube1
+	C: "OO",2058377913120,2057730468384
+	
+	;Material::lambert1, Model::pCube1
+	C: "OO",2056921590432,2057730468384
+	
+	;AnimCurveNode::T, Model::pCube1
+	C: "OP",2059091579664,2057730468384, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::pCube1
+	C: "OP",2059091580080,2057730468384, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::pCube1
+	C: "OP",2059091574880,2057730468384, "Lcl Scaling"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",2059081553280,2059091579664, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",2059081559520,2059091580080, "d|Z"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 0,70818775600
+		ReferenceTime: 0,70818775600
+	}
+}

--- a/data/maya_late_stepped_tangents_7700_ascii.fbx
+++ b/data/maya_late_stepped_tangents_7700_ascii.fbx
@@ -1,0 +1,489 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 25
+		Hour: 20
+		Minute: 48
+		Second: 51
+		Millisecond: 842
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_late_stepped_tangents_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_late_stepped_tangents_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "25/03/2024 18:48:51.841"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_late_stepped_tangents_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "25/03/2024 18:48:51.841"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",11
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",153953860000
+		P: "TimeSpanStop", "KTime", "Time", "",192442325000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 1594057846256, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 10
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceLambert" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Lambert"
+				P: "MultiLayer", "bool", "", "",0
+				P: "EmissiveColor", "Color", "", "A",0,0,0
+				P: "EmissiveFactor", "Number", "", "A",1
+				P: "AmbientColor", "Color", "", "A",0.2,0.2,0.2
+				P: "AmbientFactor", "Number", "", "A",1
+				P: "DiffuseColor", "Color", "", "A",0.8,0.8,0.8
+				P: "DiffuseFactor", "Number", "", "A",1
+				P: "Bump", "Vector3D", "Vector", "",0,0,0
+				P: "NormalMap", "Vector3D", "Vector", "",0,0,0
+				P: "BumpFactor", "double", "Number", "",1
+				P: "TransparentColor", "Color", "", "A",0,0,0
+				P: "TransparencyFactor", "Number", "", "A",0
+				P: "DisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "DisplacementFactor", "double", "Number", "",1
+				P: "VectorDisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "VectorDisplacementFactor", "double", "Number", "",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 1
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 1594369473744, "Geometry::", "Mesh" {
+		Vertices: *24 {
+			a: -0.5,-0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,-0.5,-0.5,-0.5,-0.5,0.5,-0.5,-0.5
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,1,3,-3,2,3,5,-5,4,5,7,-7,6,7,1,-1,1,7,5,-4,6,0,2,-5
+		} 
+		Edges: *12 {
+			a: 0,2,6,10,3,1,7,5,11,9,15,13
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementBinormal: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Binormals: *72 {
+				a: 0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,-0,1,0,-0,1,0,0,1,-0,-0,1,0,0,1,0,0,1,0,0,1,0,0,1,0
+			} 
+			BinormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+
+		}
+		LayerElementTangent: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Tangents: *72 {
+				a: 1,-0,-0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,-0,1,0,-0,1,0,-0,1,0,-0,0,0,-1,0,0,-1,0,-0,-1,0,0,-1,0,-0,1,0,-0,1,0,-0,1,0,-0,1
+			} 
+			TangentsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *28 {
+				a: 0.375,0,0.625,0,0.375,0.25,0.625,0.25,0.375,0.5,0.625,0.5,0.375,0.75,0.625,0.75,0.375,1,0.625,1,0.875,0,0.875,0.25,0.125,0,0.125,0.25
+			} 
+			UVIndex: *24 {
+				a: 0,1,3,2,2,3,5,4,4,5,7,6,6,7,9,8,1,10,11,3,12,0,2,13
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementBinormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementTangent"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 1594063014256, "Model::pCube1", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A+",-3,0,0
+			P: "currentUVSet", "KString", "", "U", "map1"
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 1593372925280, "Material::lambert1", "" {
+		Version: 102
+		ShadingModel: "lambert"
+		MultiLayer: 0
+		Properties70:  {
+			P: "AmbientColor", "Color", "", "A",0,0,0
+			P: "DiffuseColor", "Color", "", "A",0.5,0.5,0.5
+			P: "DiffuseFactor", "Number", "", "A",0.800000011920929
+			P: "TransparencyFactor", "Number", "", "A",1
+			P: "Emissive", "Vector3D", "Vector", "",0,0,0
+			P: "Ambient", "Vector3D", "Vector", "",0,0,0
+			P: "Diffuse", "Vector3D", "Vector", "",0.400000005960464,0.400000005960464,0.400000005960464
+			P: "Opacity", "double", "Number", "",1
+		}
+	}
+	AnimationStack: 1595067110416, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStart", "KTime", "Time", "",153953860000
+			P: "LocalStop", "KTime", "Time", "",192442325000
+			P: "ReferenceStart", "KTime", "Time", "",153953860000
+			P: "ReferenceStop", "KTime", "Time", "",192442325000
+		}
+	}
+	AnimationCurve: 1595067331744, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *5 {
+			a: 153953860000,163575976250,173198092500,182820208750,192442325000
+		} 
+		KeyValueFloat: *5 {
+			a: -3,-1,0,1,2
+		} 
+		;KeyAttrFlags: Constant|ConstantStandard, Constant|ConstantNext, Constant|ConstantNext, Constant|ConstantStandard, Cubic|TangeantUser
+		KeyAttrFlags: *5 {
+			a: 2,258,258,2,1032
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0; RightAuto:0, NextLeftAuto:4.8; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *20 {
+			a: 0,0,218434821,0,0,0,218434821,0,0,1083808154,218434821,0,0,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *5 {
+			a: 1,1,1,1,1
+		} 
+	}
+	AnimationCurveNode: 1595067112080, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",-3
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 1595067117488, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 1595067117904, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationLayer: 1595071283376, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::pCube1, Model::RootNode
+	C: "OO",1594063014256,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",1595071283376,1595067110416
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",1595067112080,1595071283376
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",1595067117488,1595071283376
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",1595067117904,1595071283376
+	
+	;Geometry::, Model::pCube1
+	C: "OO",1594369473744,1594063014256
+	
+	;Material::lambert1, Model::pCube1
+	C: "OO",1593372925280,1594063014256
+	
+	;AnimCurveNode::T, Model::pCube1
+	C: "OP",1595067112080,1594063014256, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::pCube1
+	C: "OP",1595067117904,1594063014256, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::pCube1
+	C: "OP",1595067117488,1594063014256, "Lcl Scaling"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",1595067331744,1595067112080, "d|X"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 153953860000,192442325000
+		ReferenceTime: 153953860000,192442325000
+	}
+}

--- a/data/maya_scale_no_inherit_step_7700_ascii.fbx
+++ b/data/maya_scale_no_inherit_step_7700_ascii.fbx
@@ -1,0 +1,379 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 26
+		Hour: 2
+		Minute: 4
+		Second: 40
+		Millisecond: 77
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_scale_no_inherit_step_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_scale_no_inherit_step_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "26/03/2024 00:04:40.076"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_scale_no_inherit_step_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "26/03/2024 00:04:40.076"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Left"
+		P: "TimeMode", "enum", "", "",11
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",0
+		P: "TimeSpanStop", "KTime", "Time", "",192442325000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 1592052722144, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 11
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "NodeAttribute" {
+		Count: 2
+		PropertyTemplate: "FbxSkeleton" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "Size", "double", "Number", "",100
+				P: "LimbLength", "double", "Number", "H",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 2
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 1
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	NodeAttribute: 1591849549968, "NodeAttribute::", "LimbNode" {
+		Properties70:  {
+			P: "Size", "double", "Number", "",23.5632183908046
+		}
+		TypeFlags: "Skeleton"
+	}
+	NodeAttribute: 1591849550544, "NodeAttribute::", "LimbNode" {
+		Properties70:  {
+			P: "Size", "double", "Number", "",23.5632183908046
+		}
+		TypeFlags: "Skeleton"
+	}
+	Model: 1594063025856, "Model::joint1", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "PreRotation", "Vector3D", "Vector", "",0,-0,90
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Scaling", "Lcl Scaling", "", "A+",2,1,1
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 1594063011936, "Model::joint2", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",2
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",5,0,0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	AnimationStack: 1592055193680, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStop", "KTime", "Time", "",38488465000
+			P: "ReferenceStop", "KTime", "Time", "",38488465000
+		}
+	}
+	AnimationCurve: 1591861088016, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *4 {
+			a: 0,9622116250,19244232500,28866348750
+		} 
+		KeyValueFloat: *4 {
+			a: 2,3,4,5
+		} 
+		;KeyAttrFlags: Constant|ConstantStandard, Linear, Constant|ConstantNext, Cubic|TangeantUser
+		KeyAttrFlags: *4 {
+			a: 2,1028,258,1032
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:4.8, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:4.8, NextLeftSlope:4.8, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *16 {
+			a: 0,1083808154,218434821,0,1083808154,1083808154,218434821,0,0,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *4 {
+			a: 1,1,1,1
+		} 
+	}
+	AnimationCurveNode: 1592055186608, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 1592055194928, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",2
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 1592055182240, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationLayer: 1594046711360, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::joint1, Model::RootNode
+	C: "OO",1594063025856,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",1594046711360,1592055193680
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",1592055186608,1594046711360
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",1592055194928,1594046711360
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",1592055182240,1594046711360
+	
+	;NodeAttribute::, Model::joint1
+	C: "OO",1591849549968,1594063025856
+	
+	;Model::joint2, Model::joint1
+	C: "OO",1594063011936,1594063025856
+	
+	;AnimCurveNode::T, Model::joint1
+	C: "OP",1592055186608,1594063025856, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::joint1
+	C: "OP",1592055182240,1594063025856, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::joint1
+	C: "OP",1592055194928,1594063025856, "Lcl Scaling"
+	
+	;NodeAttribute::, Model::joint2
+	C: "OO",1591849550544,1594063011936
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",1591861088016,1592055194928, "d|X"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 0,38488465000
+		ReferenceTime: 0,38488465000
+	}
+}

--- a/data/maya_stepped_tangent_sign_7700_ascii.fbx
+++ b/data/maya_stepped_tangent_sign_7700_ascii.fbx
@@ -1,0 +1,489 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2024
+		Month: 3
+		Day: 24
+		Hour: 17
+		Minute: 17
+		Second: 0
+		Millisecond: 364
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_stepped_tangent_sign_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\maya_stepped_tangent_sign_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "Maya"
+			P: "Original|ApplicationVersion", "KString", "", "", "2023"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "24/03/2024 15:17:00.363"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\maya_stepped_tangent_sign_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "Maya"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2023"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "24/03/2024 15:17:00.363"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "D:\Dev\clean\ufbx\data"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",0
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",-92372316000
+		P: "TimeSpanStop", "KTime", "Time", "",92372316000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 2111936665056, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", "Take 001"
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 10
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceLambert" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Lambert"
+				P: "MultiLayer", "bool", "", "",0
+				P: "EmissiveColor", "Color", "", "A",0,0,0
+				P: "EmissiveFactor", "Number", "", "A",1
+				P: "AmbientColor", "Color", "", "A",0.2,0.2,0.2
+				P: "AmbientFactor", "Number", "", "A",1
+				P: "DiffuseColor", "Color", "", "A",0.8,0.8,0.8
+				P: "DiffuseFactor", "Number", "", "A",1
+				P: "Bump", "Vector3D", "Vector", "",0,0,0
+				P: "NormalMap", "Vector3D", "Vector", "",0,0,0
+				P: "BumpFactor", "double", "Number", "",1
+				P: "TransparentColor", "Color", "", "A",0,0,0
+				P: "TransparencyFactor", "Number", "", "A",0
+				P: "DisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "DisplacementFactor", "double", "Number", "",1
+				P: "VectorDisplacementColor", "ColorRGB", "Color", "",0,0,0
+				P: "VectorDisplacementFactor", "double", "Number", "",1
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 1
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 3
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 2111929072272, "Geometry::", "Mesh" {
+		Vertices: *24 {
+			a: -0.5,-0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,0.5,0.5,0.5,-0.5,0.5,-0.5,0.5,0.5,-0.5,-0.5,-0.5,-0.5,0.5,-0.5,-0.5
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,1,3,-3,2,3,5,-5,4,5,7,-7,6,7,1,-1,1,7,5,-4,6,0,2,-5
+		} 
+		Edges: *12 {
+			a: 0,2,6,10,3,1,7,5,11,9,15,13
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementBinormal: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Binormals: *72 {
+				a: 0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,-0,1,0,-0,1,0,0,1,-0,-0,1,0,0,1,0,0,1,0,0,1,0,0,1,0
+			} 
+			BinormalsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+
+		}
+		LayerElementTangent: 0 {
+			Version: 102
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Tangents: *72 {
+				a: 1,-0,-0,1,-0,0,1,-0,0,1,-0,0,1,-0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,-0,1,0,-0,1,0,-0,1,0,-0,0,0,-1,0,0,-1,0,-0,-1,0,0,-1,0,-0,1,0,-0,1,0,-0,1,0,-0,1
+			} 
+			TangentsW: *24 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "map1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *28 {
+				a: 0.375,0,0.625,0,0.375,0.25,0.625,0.25,0.375,0.5,0.625,0.5,0.375,0.75,0.625,0.75,0.375,1,0.625,1,0.875,0,0.875,0.25,0.125,0,0.125,0.25
+			} 
+			UVIndex: *24 {
+				a: 0,1,3,2,2,3,5,4,4,5,7,6,6,7,9,8,1,10,11,3,12,0,2,13
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementBinormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementTangent"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 2111379615824, "Model::pCube1", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A+",-1,0,0
+			P: "currentUVSet", "KString", "", "U", "map1"
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 2111594483744, "Material::lambert1", "" {
+		Version: 102
+		ShadingModel: "lambert"
+		MultiLayer: 0
+		Properties70:  {
+			P: "AmbientColor", "Color", "", "A",0,0,0
+			P: "DiffuseColor", "Color", "", "A",0.5,0.5,0.5
+			P: "DiffuseFactor", "Number", "", "A",0.800000011920929
+			P: "TransparencyFactor", "Number", "", "A",1
+			P: "Emissive", "Vector3D", "Vector", "",0,0,0
+			P: "Ambient", "Vector3D", "Vector", "",0,0,0
+			P: "Diffuse", "Vector3D", "Vector", "",0.400000005960464,0.400000005960464,0.400000005960464
+			P: "Opacity", "double", "Number", "",1
+		}
+	}
+	AnimationStack: 2112588473920, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStart", "KTime", "Time", "",-92372316000
+			P: "LocalStop", "KTime", "Time", "",92372316000
+			P: "ReferenceStart", "KTime", "Time", "",-92372316000
+			P: "ReferenceStop", "KTime", "Time", "",92372316000
+		}
+	}
+	AnimationCurve: 2112586843648, "AnimCurve::", "" {
+		Default: 0
+		KeyVer: 4009
+		KeyTime: *6 {
+			a: -92372316000,-46186158000,-4618615800,4618615800,46186158000,92372316000
+		} 
+		KeyValueFloat: *6 {
+			a: -3,-2,-1,1,2,3
+		} 
+		;KeyAttrFlags: Constant|ConstantStandard, Constant|ConstantNext, Linear, Constant|ConstantStandard, Constant|ConstantNext, Cubic|TangeantUser
+		KeyAttrFlags: *6 {
+			a: 2,258,1028,2,258,1032
+		} 
+		;KeyAttrDataFloat: RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:1.11111; RightSlope:10, NextLeftSlope:10, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0; RightAuto:0, NextLeftAuto:0; RightSlope:0, NextLeftSlope:0, RightWeight:0.333333, NextLeftWeight:0.333333, RightVelocity:0, NextLeftVelocity:0
+		KeyAttrDataFloat: *24 {
+			a: 0,0,218434821,0,0,1066285284,218434821,0,1092616192,1092616192,218434821,0,0,0,218434821,0,0,0,218434821,0,0,0,218434821,0
+		} 
+		KeyAttrRefCount: *6 {
+			a: 1,1,1,1,1,1
+		} 
+	}
+	AnimationCurveNode: 2112588476000, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",-1
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 2112588476832, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 2112588473088, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationLayer: 2111571655136, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::pCube1, Model::RootNode
+	C: "OO",2111379615824,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",2111571655136,2112588473920
+	
+	;AnimCurveNode::T, AnimLayer::BaseLayer
+	C: "OO",2112588476000,2111571655136
+	
+	;AnimCurveNode::S, AnimLayer::BaseLayer
+	C: "OO",2112588476832,2111571655136
+	
+	;AnimCurveNode::R, AnimLayer::BaseLayer
+	C: "OO",2112588473088,2111571655136
+	
+	;Geometry::, Model::pCube1
+	C: "OO",2111929072272,2111379615824
+	
+	;Material::lambert1, Model::pCube1
+	C: "OO",2111594483744,2111379615824
+	
+	;AnimCurveNode::T, Model::pCube1
+	C: "OP",2112588476000,2111379615824, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::pCube1
+	C: "OP",2112588473088,2111379615824, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::pCube1
+	C: "OP",2112588476832,2111379615824, "Lcl Scaling"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",2112586843648,2112588476000, "d|X"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: "Take 001"
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: -92372316000,92372316000
+		ReferenceTime: -92372316000,92372316000
+	}
+}

--- a/misc/fdlibm.c
+++ b/misc/fdlibm.c
@@ -4,7 +4,7 @@
  *
  * Developed at SunSoft, a Sun Microsystems, Inc. business.
  * Permission to use, copy, modify, and distribute this
- * software is freely granted, provided that this notice 
+ * software is freely granted, provided that this notice
  * is preserved.
  * ====================================================
  */
@@ -16,34 +16,36 @@
 	#define __LITTLE_ENDIAN
 #endif
 
-typedef union {
+typedef union
+{
 	double d;
 	int i[2];
 } fdlibm_bits;
 
-typedef union {
+typedef union
+{
 	float f;
 	int i;
 } fdlibmf_bits;
 
 #ifdef __LITTLE_ENDIAN
-	#define __HI(x) (((fdlibm_bits*)&(x))->i[1])
-	#define __LO(x) (((fdlibm_bits*)&(x))->i[0])
+	#define __HI(x) (((fdlibm_bits *)&(x))->i[1])
+	#define __LO(x) (((fdlibm_bits *)&(x))->i[0])
 #else
-	#define __HI(x) (((fdlibm_bits*)&(x))->i[0])
-	#define __LO(x) (((fdlibm_bits*)&(x))->i[1])
+	#define __HI(x) (((fdlibm_bits *)&(x))->i[0])
+	#define __LO(x) (((fdlibm_bits *)&(x))->i[1])
 #endif
-#define __FLT(x) (((fdlibmf_bits*)&(x))->i)
+#define __FLT(x) (((fdlibmf_bits *)&(x))->i)
 
-/* 
+/*
  * set X_TLOSS = pi*2**52, which is possibly defined in <values.h>
  * (one may replace the following line by "#include <values.h>")
  */
 
 double fdlibm_copysign(double x, double y)
 {
-	__HI(x) = (__HI(x)&0x7fffffff)|(__HI(y)&0x80000000);
-        return x;
+	__HI(x) = (__HI(x) & 0x7fffffff) | (__HI(y) & 0x80000000);
+	return x;
 }
 
 double fdlibm_fabs(double x)
@@ -55,78 +57,115 @@ double fdlibm_fabs(double x)
 double fdlibm_scalbn(double x, int n)
 {
 	static const double
-		two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
-		twom54  =  5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
-		huge   = 1.0e+300,
-		tiny   = 1.0e-300;
+		two54 = 1.80143985094819840000e+16,	 /* 0x43500000, 0x00000000 */
+		twom54 = 5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
+		huge = 1.0e+300,
+		tiny = 1.0e-300;
 
-	int  k,hx,lx;
+	int k, hx, lx;
 	hx = __HI(x);
 	lx = __LO(x);
-        k = (hx&0x7ff00000)>>20;		/* extract exponent */
-        if (k==0) {				/* 0 or subnormal x */
-            if ((lx|(hx&0x7fffffff))==0) return x; /* +-0 */
-	    x *= two54; 
-	    hx = __HI(x);
-	    k = ((hx&0x7ff00000)>>20) - 54; 
-            if (n< -50000) return tiny*x; 	/*underflow*/
-	    }
-        if (k==0x7ff) return x+x;		/* NaN or Inf */
-        k = k+n; 
-        if (k >  0x7fe) return huge*fdlibm_copysign(huge,x); /* overflow  */
-        if (k > 0) 				/* normal result */
-	    {__HI(x) = (hx&0x800fffff)|(k<<20); return x;}
-        if (k <= -54) {
-            if (n > 50000) 	/* in case integer overflow in n+k */
-			return huge*fdlibm_copysign(huge,x);	/*overflow*/
-			else return tiny*fdlibm_copysign(tiny,x); 	/*underflow*/
-		}
-        k += 54;				/* subnormal result */
-        __HI(x) = (hx&0x800fffff)|(k<<20);
-        return x*twom54;
+	k = (hx & 0x7ff00000) >> 20; /* extract exponent */
+	if (k == 0)
+	{ /* 0 or subnormal x */
+		if ((lx | (hx & 0x7fffffff)) == 0)
+			return x; /* +-0 */
+		x *= two54;
+		hx = __HI(x);
+		k = ((hx & 0x7ff00000) >> 20) - 54;
+		if (n < -50000)
+			return tiny * x; /*underflow*/
+	}
+	if (k == 0x7ff)
+		return x + x; /* NaN or Inf */
+	k = k + n;
+	if (k > 0x7fe)
+		return huge * fdlibm_copysign(huge, x); /* overflow  */
+	if (k > 0)									/* normal result */
+	{
+		__HI(x) = (hx & 0x800fffff) | (k << 20);
+		return x;
+	}
+	if (k <= -54)
+	{
+		if (n > 50000)								/* in case integer overflow in n+k */
+			return huge * fdlibm_copysign(huge, x); /*overflow*/
+		else
+			return tiny * fdlibm_copysign(tiny, x); /*underflow*/
+	}
+	k += 54; /* subnormal result */
+	__HI(x) = (hx & 0x800fffff) | (k << 20);
+	return x * twom54;
 }
 
 double fdlibm_floor(double x)
 {
 	static const double huge = 1.0e300;
 
-	int i0,i1,j0;
-	unsigned i,j;
-	i0 =  __HI(x);
-	i1 =  __LO(x);
-	j0 = ((i0>>20)&0x7ff)-0x3ff;
-	if(j0<20) {
-	    if(j0<0) { 	/* raise inexact if x != 0 */
-		if(huge+x>0.0) {/* return 0*sign(x) if |x|<1 */
-		    if(i0>=0) {i0=i1=0;} 
-		    else if(((i0&0x7fffffff)|i1)!=0)
-			{ i0=0xbff00000;i1=0;}
+	int i0, i1, j0;
+	unsigned i, j;
+	i0 = __HI(x);
+	i1 = __LO(x);
+	j0 = ((i0 >> 20) & 0x7ff) - 0x3ff;
+	if (j0 < 20)
+	{
+		if (j0 < 0)
+		{ /* raise inexact if x != 0 */
+			if (huge + x > 0.0)
+			{ /* return 0*sign(x) if |x|<1 */
+				if (i0 >= 0)
+				{
+					i0 = i1 = 0;
+				}
+				else if (((i0 & 0x7fffffff) | i1) != 0)
+				{
+					i0 = 0xbff00000;
+					i1 = 0;
+				}
+			}
 		}
-	    } else {
-		i = (0x000fffff)>>j0;
-		if(((i0&i)|i1)==0) return x; /* x is integral */
-		if(huge+x>0.0) {	/* raise inexact flag */
-		    if(i0<0) i0 += (0x00100000)>>j0;
-		    i0 &= (~i); i1=0;
+		else
+		{
+			i = (0x000fffff) >> j0;
+			if (((i0 & i) | i1) == 0)
+				return x; /* x is integral */
+			if (huge + x > 0.0)
+			{ /* raise inexact flag */
+				if (i0 < 0)
+					i0 += (0x00100000) >> j0;
+				i0 &= (~i);
+				i1 = 0;
+			}
 		}
-	    }
-	} else if (j0>51) {
-	    if(j0==0x400) return x+x;	/* inf or NaN */
-	    else return x;		/* x is integral */
-	} else {
-	    i = ((unsigned)(0xffffffff))>>(j0-20);
-	    if((i1&i)==0) return x;	/* x is integral */
-	    if(huge+x>0.0) { 		/* raise inexact flag */
-		if(i0<0) {
-		    if(j0==20) i0+=1; 
-		    else {
-			j = i1+(1<<(52-j0));
-			if(j<(unsigned)i1) i0 +=1 ; 	/* got a carry */
-			i1=j;
-		    }
+	}
+	else if (j0 > 51)
+	{
+		if (j0 == 0x400)
+			return x + x; /* inf or NaN */
+		else
+			return x; /* x is integral */
+	}
+	else
+	{
+		i = ((unsigned)(0xffffffff)) >> (j0 - 20);
+		if ((i1 & i) == 0)
+			return x; /* x is integral */
+		if (huge + x > 0.0)
+		{ /* raise inexact flag */
+			if (i0 < 0)
+			{
+				if (j0 == 20)
+					i0 += 1;
+				else
+				{
+					j = i1 + (1 << (52 - j0));
+					if (j < (unsigned)i1)
+						i0 += 1; /* got a carry */
+					i1 = j;
+				}
+			}
+			i1 &= (~i);
 		}
-		i1 &= (~i);
-	    }
 	}
 	__HI(x) = i0;
 	__LO(x) = i1;
@@ -136,22 +175,24 @@ double fdlibm_floor(double x)
 double fdlibm_frexp(double x, int *eptr)
 {
 	static const double
-		two54 =  1.80143985094819840000e+16; /* 0x43500000, 0x00000000 */
+		two54 = 1.80143985094819840000e+16; /* 0x43500000, 0x00000000 */
 
-	int  hx, ix, lx;
+	int hx, ix, lx;
 	hx = __HI(x);
-	ix = 0x7fffffff&hx;
+	ix = 0x7fffffff & hx;
 	lx = __LO(x);
 	*eptr = 0;
-	if(ix>=0x7ff00000||((ix|lx)==0)) return x;	/* 0,inf,nan */
-	if (ix<0x00100000) {		/* subnormal */
-	    x *= two54;
-	    hx = __HI(x);
-	    ix = hx&0x7fffffff;
-	    *eptr = -54;
+	if (ix >= 0x7ff00000 || ((ix | lx) == 0))
+		return x; /* 0,inf,nan */
+	if (ix < 0x00100000)
+	{ /* subnormal */
+		x *= two54;
+		hx = __HI(x);
+		ix = hx & 0x7fffffff;
+		*eptr = -54;
 	}
-	*eptr += (ix>>20)-1022;
-	hx = (hx&0x800fffff)|0x3fe00000;
+	*eptr += (ix >> 20) - 1022;
+	hx = (hx & 0x800fffff) | 0x3fe00000;
 	__HI(x) = hx;
 	return x;
 }
@@ -160,810 +201,1118 @@ double fdlibm_atan(double x)
 {
 
 	static const double atanhi[] = {
-	  4.63647609000806093515e-01, /* atan(0.5)hi 0x3FDDAC67, 0x0561BB4F */
-	  7.85398163397448278999e-01, /* atan(1.0)hi 0x3FE921FB, 0x54442D18 */
-	  9.82793723247329054082e-01, /* atan(1.5)hi 0x3FEF730B, 0xD281F69B */
-	  1.57079632679489655800e+00, /* atan(inf)hi 0x3FF921FB, 0x54442D18 */
+		4.63647609000806093515e-01, /* atan(0.5)hi 0x3FDDAC67, 0x0561BB4F */
+		7.85398163397448278999e-01, /* atan(1.0)hi 0x3FE921FB, 0x54442D18 */
+		9.82793723247329054082e-01, /* atan(1.5)hi 0x3FEF730B, 0xD281F69B */
+		1.57079632679489655800e+00, /* atan(inf)hi 0x3FF921FB, 0x54442D18 */
 	};
 
 	static const double atanlo[] = {
-	  2.26987774529616870924e-17, /* atan(0.5)lo 0x3C7A2B7F, 0x222F65E2 */
-	  3.06161699786838301793e-17, /* atan(1.0)lo 0x3C81A626, 0x33145C07 */
-	  1.39033110312309984516e-17, /* atan(1.5)lo 0x3C700788, 0x7AF0CBBD */
-	  6.12323399573676603587e-17, /* atan(inf)lo 0x3C91A626, 0x33145C07 */
+		2.26987774529616870924e-17, /* atan(0.5)lo 0x3C7A2B7F, 0x222F65E2 */
+		3.06161699786838301793e-17, /* atan(1.0)lo 0x3C81A626, 0x33145C07 */
+		1.39033110312309984516e-17, /* atan(1.5)lo 0x3C700788, 0x7AF0CBBD */
+		6.12323399573676603587e-17, /* atan(inf)lo 0x3C91A626, 0x33145C07 */
 	};
 
 	static const double aT[] = {
-	  3.33333333333329318027e-01, /* 0x3FD55555, 0x5555550D */
-	 -1.99999999998764832476e-01, /* 0xBFC99999, 0x9998EBC4 */
-	  1.42857142725034663711e-01, /* 0x3FC24924, 0x920083FF */
-	 -1.11111104054623557880e-01, /* 0xBFBC71C6, 0xFE231671 */
-	  9.09088713343650656196e-02, /* 0x3FB745CD, 0xC54C206E */
-	 -7.69187620504482999495e-02, /* 0xBFB3B0F2, 0xAF749A6D */
-	  6.66107313738753120669e-02, /* 0x3FB10D66, 0xA0D03D51 */
-	 -5.83357013379057348645e-02, /* 0xBFADDE2D, 0x52DEFD9A */
-	  4.97687799461593236017e-02, /* 0x3FA97B4B, 0x24760DEB */
-	 -3.65315727442169155270e-02, /* 0xBFA2B444, 0x2C6A6C2F */
-	  1.62858201153657823623e-02, /* 0x3F90AD3A, 0xE322DA11 */
+		3.33333333333329318027e-01,	 /* 0x3FD55555, 0x5555550D */
+		-1.99999999998764832476e-01, /* 0xBFC99999, 0x9998EBC4 */
+		1.42857142725034663711e-01,	 /* 0x3FC24924, 0x920083FF */
+		-1.11111104054623557880e-01, /* 0xBFBC71C6, 0xFE231671 */
+		9.09088713343650656196e-02,	 /* 0x3FB745CD, 0xC54C206E */
+		-7.69187620504482999495e-02, /* 0xBFB3B0F2, 0xAF749A6D */
+		6.66107313738753120669e-02,	 /* 0x3FB10D66, 0xA0D03D51 */
+		-5.83357013379057348645e-02, /* 0xBFADDE2D, 0x52DEFD9A */
+		4.97687799461593236017e-02,	 /* 0x3FA97B4B, 0x24760DEB */
+		-3.65315727442169155270e-02, /* 0xBFA2B444, 0x2C6A6C2F */
+		1.62858201153657823623e-02,	 /* 0x3F90AD3A, 0xE322DA11 */
 	};
 
-	static const double 
-		one   = 1.0,
-		huge   = 1.0e300;
+	static const double
+		one = 1.0,
+		huge = 1.0e300;
 
-	double w,s1,s2,z;
-	int ix,hx,id;
+	double w, s1, s2, z;
+	int ix, hx, id;
 
 	hx = __HI(x);
-	ix = hx&0x7fffffff;
-	if(ix>=0x44100000) {	/* if |x| >= 2^66 */
-	    if(ix>0x7ff00000||
-		(ix==0x7ff00000&&(__LO(x)!=0)))
-		return x+x;		/* NaN */
-	    if(hx>0) return  atanhi[3]+atanlo[3];
-	    else     return -atanhi[3]-atanlo[3];
-	} if (ix < 0x3fdc0000) {	/* |x| < 0.4375 */
-	    if (ix < 0x3e200000) {	/* |x| < 2^-29 */
-		if(huge+x>one) return x;	/* raise inexact */
-	    }
-	    id = -1;
-	} else {
-	x = fdlibm_fabs(x);
-	if (ix < 0x3ff30000) {		/* |x| < 1.1875 */
-	    if (ix < 0x3fe60000) {	/* 7/16 <=|x|<11/16 */
-		id = 0; x = (2.0*x-one)/(2.0+x); 
-	    } else {			/* 11/16<=|x|< 19/16 */
-		id = 1; x  = (x-one)/(x+one); 
-	    }
-	} else {
-	    if (ix < 0x40038000) {	/* |x| < 2.4375 */
-		id = 2; x  = (x-1.5)/(one+1.5*x);
-	    } else {			/* 2.4375 <= |x| < 2^66 */
-		id = 3; x  = -1.0/x;
-	    }
-	}}
-    /* end of argument reduction */
-	z = x*x;
-	w = z*z;
-    /* break sum from i=0 to 10 aT[i]z**(i+1) into odd and even poly */
-	s1 = z*(aT[0]+w*(aT[2]+w*(aT[4]+w*(aT[6]+w*(aT[8]+w*aT[10])))));
-	s2 = w*(aT[1]+w*(aT[3]+w*(aT[5]+w*(aT[7]+w*aT[9]))));
-	if (id<0) return x - x*(s1+s2);
-	else {
-	    z = atanhi[id] - ((x*(s1+s2) - atanlo[id]) - x);
-	    return (hx<0)? -z:z;
+	ix = hx & 0x7fffffff;
+	if (ix >= 0x44100000)
+	{ /* if |x| >= 2^66 */
+		if (ix > 0x7ff00000 ||
+			(ix == 0x7ff00000 && (__LO(x) != 0)))
+			return x + x; /* NaN */
+		if (hx > 0)
+			return atanhi[3] + atanlo[3];
+		else
+			return -atanhi[3] - atanlo[3];
+	}
+	if (ix < 0x3fdc0000)
+	{ /* |x| < 0.4375 */
+		if (ix < 0x3e200000)
+		{ /* |x| < 2^-29 */
+			if (huge + x > one)
+				return x; /* raise inexact */
+		}
+		id = -1;
+	}
+	else
+	{
+		x = fdlibm_fabs(x);
+		if (ix < 0x3ff30000)
+		{ /* |x| < 1.1875 */
+			if (ix < 0x3fe60000)
+			{ /* 7/16 <=|x|<11/16 */
+				id = 0;
+				x = (2.0 * x - one) / (2.0 + x);
+			}
+			else
+			{ /* 11/16<=|x|< 19/16 */
+				id = 1;
+				x = (x - one) / (x + one);
+			}
+		}
+		else
+		{
+			if (ix < 0x40038000)
+			{ /* |x| < 2.4375 */
+				id = 2;
+				x = (x - 1.5) / (one + 1.5 * x);
+			}
+			else
+			{ /* 2.4375 <= |x| < 2^66 */
+				id = 3;
+				x = -1.0 / x;
+			}
+		}
+	}
+	/* end of argument reduction */
+	z = x * x;
+	w = z * z;
+	/* break sum from i=0 to 10 aT[i]z**(i+1) into odd and even poly */
+	s1 = z * (aT[0] + w * (aT[2] + w * (aT[4] + w * (aT[6] + w * (aT[8] + w * aT[10])))));
+	s2 = w * (aT[1] + w * (aT[3] + w * (aT[5] + w * (aT[7] + w * aT[9]))));
+	if (id < 0)
+		return x - x * (s1 + s2);
+	else
+	{
+		z = atanhi[id] - ((x * (s1 + s2) - atanlo[id]) - x);
+		return (hx < 0) ? -z : z;
 	}
 }
 
 static double __ieee754_sqrt(double x)
 {
-	static	const double	one	= 1.0, tiny=1.0e-300;
+	static const double one = 1.0, tiny = 1.0e-300;
 
 	double z;
-	int 	sign = (int)0x80000000; 
-	unsigned r,t1,s1,ix1,q1;
-	int ix0,s0,q,m,t,i;
+	int sign = (int)0x80000000;
+	unsigned r, t1, s1, ix1, q1;
+	int ix0, s0, q, m, t, i;
 
-	ix0 = __HI(x);			/* high word of x */
-	ix1 = __LO(x);		/* low word of x */
+	ix0 = __HI(x); /* high word of x */
+	ix1 = __LO(x); /* low word of x */
 
-    /* take care of Inf and NaN */
-	if((ix0&0x7ff00000)==0x7ff00000) {			
-	    return x*x+x;		/* sqrt(NaN)=NaN, sqrt(+inf)=+inf
-					   sqrt(-inf)=sNaN */
-	} 
-    /* take care of zero */
-	if(ix0<=0) {
-	    if(((ix0&(~sign))|ix1)==0) return x;/* sqrt(+-0) = +-0 */
-	    else if(ix0<0)
-		return (x-x)/(x-x);		/* sqrt(-ve) = sNaN */
+	/* take care of Inf and NaN */
+	if ((ix0 & 0x7ff00000) == 0x7ff00000)
+	{
+		return x * x + x; /* sqrt(NaN)=NaN, sqrt(+inf)=+inf
+					 sqrt(-inf)=sNaN */
 	}
-    /* normalize x */
-	m = (ix0>>20);
-	if(m==0) {				/* subnormal x */
-	    while(ix0==0) {
-		m -= 21;
-		ix0 |= (ix1>>11); ix1 <<= 21;
-	    }
-	    for(i=0;(ix0&0x00100000)==0;i++) ix0<<=1;
-	    m -= i-1;
-	    ix0 |= (ix1>>(32-i));
-	    ix1 <<= i;
+	/* take care of zero */
+	if (ix0 <= 0)
+	{
+		if (((ix0 & (~sign)) | ix1) == 0)
+			return x; /* sqrt(+-0) = +-0 */
+		else if (ix0 < 0)
+			return (x - x) / (x - x); /* sqrt(-ve) = sNaN */
 	}
-	m -= 1023;	/* unbias exponent */
-	ix0 = (ix0&0x000fffff)|0x00100000;
-	if(m&1){	/* odd m, double x to make it even */
-	    ix0 += ix0 + ((ix1&sign)>>31);
-	    ix1 += ix1;
+	/* normalize x */
+	m = (ix0 >> 20);
+	if (m == 0)
+	{ /* subnormal x */
+		while (ix0 == 0)
+		{
+			m -= 21;
+			ix0 |= (ix1 >> 11);
+			ix1 <<= 21;
+		}
+		for (i = 0; (ix0 & 0x00100000) == 0; i++)
+			ix0 <<= 1;
+		m -= i - 1;
+		ix0 |= (ix1 >> (32 - i));
+		ix1 <<= i;
 	}
-	m >>= 1;	/* m = [m/2] */
+	m -= 1023; /* unbias exponent */
+	ix0 = (ix0 & 0x000fffff) | 0x00100000;
+	if (m & 1)
+	{ /* odd m, double x to make it even */
+		ix0 += ix0 + ((ix1 & sign) >> 31);
+		ix1 += ix1;
+	}
+	m >>= 1; /* m = [m/2] */
 
-    /* generate sqrt(x) bit by bit */
-	ix0 += ix0 + ((ix1&sign)>>31);
+	/* generate sqrt(x) bit by bit */
+	ix0 += ix0 + ((ix1 & sign) >> 31);
 	ix1 += ix1;
-	q = q1 = s0 = s1 = 0;	/* [q,q1] = sqrt(x) */
-	r = 0x00200000;		/* r = moving bit from right to left */
+	q = q1 = s0 = s1 = 0; /* [q,q1] = sqrt(x) */
+	r = 0x00200000;		  /* r = moving bit from right to left */
 
-	while(r!=0) {
-	    t = s0+r; 
-	    if(t<=ix0) { 
-		s0   = t+r; 
-		ix0 -= t; 
-		q   += r; 
-	    } 
-	    ix0 += ix0 + ((ix1&sign)>>31);
-	    ix1 += ix1;
-	    r>>=1;
+	while (r != 0)
+	{
+		t = s0 + r;
+		if (t <= ix0)
+		{
+			s0 = t + r;
+			ix0 -= t;
+			q += r;
+		}
+		ix0 += ix0 + ((ix1 & sign) >> 31);
+		ix1 += ix1;
+		r >>= 1;
 	}
 
 	r = sign;
-	while(r!=0) {
-	    t1 = s1+r; 
-	    t  = s0;
-	    if((t<ix0)||((t==ix0)&&(t1<=ix1))) { 
-		s1  = t1+r;
-		if(((t1&sign)==sign)&&(s1&sign)==0) s0 += 1;
-		ix0 -= t;
-		if (ix1 < t1) ix0 -= 1;
-		ix1 -= t1;
-		q1  += r;
-	    }
-	    ix0 += ix0 + ((ix1&sign)>>31);
-	    ix1 += ix1;
-	    r>>=1;
+	while (r != 0)
+	{
+		t1 = s1 + r;
+		t = s0;
+		if ((t < ix0) || ((t == ix0) && (t1 <= ix1)))
+		{
+			s1 = t1 + r;
+			if (((t1 & sign) == sign) && (s1 & sign) == 0)
+				s0 += 1;
+			ix0 -= t;
+			if (ix1 < t1)
+				ix0 -= 1;
+			ix1 -= t1;
+			q1 += r;
+		}
+		ix0 += ix0 + ((ix1 & sign) >> 31);
+		ix1 += ix1;
+		r >>= 1;
 	}
 
-    /* use floating add to find out rounding direction */
-	if((ix0|ix1)!=0) {
-	    z = one-tiny; /* trigger inexact flag */
-	    if (z>=one) {
-	        z = one+tiny;
-	        if (q1==(unsigned)0xffffffff) { q1=0; q += 1;}
-		else if (z>one) {
-		    if (q1==(unsigned)0xfffffffe) q+=1;
-		    q1+=2; 
-		} else
-	            q1 += (q1&1);
-	    }
+	/* use floating add to find out rounding direction */
+	if ((ix0 | ix1) != 0)
+	{
+		z = one - tiny; /* trigger inexact flag */
+		if (z >= one)
+		{
+			z = one + tiny;
+			if (q1 == (unsigned)0xffffffff)
+			{
+				q1 = 0;
+				q += 1;
+			}
+			else if (z > one)
+			{
+				if (q1 == (unsigned)0xfffffffe)
+					q += 1;
+				q1 += 2;
+			}
+			else
+				q1 += (q1 & 1);
+		}
 	}
-	ix0 = (q>>1)+0x3fe00000;
-	ix1 =  q1>>1;
-	if ((q&1)==1) ix1 |= sign;
-	ix0 += (m <<20);
+	ix0 = (q >> 1) + 0x3fe00000;
+	ix1 = q1 >> 1;
+	if ((q & 1) == 1)
+		ix1 |= sign;
+	ix0 += (m << 20);
 	__HI(z) = ix0;
 	__LO(z) = ix1;
 	return z;
 }
 
-double fdlibm_sqrt(double x)		/* wrapper sqrt */
+double fdlibm_sqrt(double x) /* wrapper sqrt */
 {
 	return __ieee754_sqrt(x);
 }
 
 static double __ieee754_pow(double x, double y)
 {
-	static const double 
-	bp[] = {1.0, 1.5,},
-	dp_h[] = { 0.0, 5.84962487220764160156e-01,}, /* 0x3FE2B803, 0x40000000 */
-	dp_l[] = { 0.0, 1.35003920212974897128e-08,}, /* 0x3E4CFDEB, 0x43CFD006 */
-	zero    =  0.0,
-	one	=  1.0,
-	two	=  2.0,
-	two53	=  9007199254740992.0,	/* 0x43400000, 0x00000000 */
-	huge	=  1.0e300,
-	tiny    =  1.0e-300,
+	static const double
+		bp[] = {
+			1.0,
+			1.5,
+		},
+		dp_h[] = {
+			0.0,
+			5.84962487220764160156e-01,
+		}, /* 0x3FE2B803, 0x40000000 */
+		dp_l[] = {
+			0.0,
+			1.35003920212974897128e-08,
+		},															  /* 0x3E4CFDEB, 0x43CFD006 */
+		zero = 0.0, one = 1.0, two = 2.0, two53 = 9007199254740992.0, /* 0x43400000, 0x00000000 */
+		huge = 1.0e300, tiny = 1.0e-300,
 		/* poly coefs for (3/2)*(log(x)-2s-2/3*s**3 */
-	L1  =  5.99999999999994648725e-01, /* 0x3FE33333, 0x33333303 */
-	L2  =  4.28571428578550184252e-01, /* 0x3FDB6DB6, 0xDB6FABFF */
-	L3  =  3.33333329818377432918e-01, /* 0x3FD55555, 0x518F264D */
-	L4  =  2.72728123808534006489e-01, /* 0x3FD17460, 0xA91D4101 */
-	L5  =  2.30660745775561754067e-01, /* 0x3FCD864A, 0x93C9DB65 */
-	L6  =  2.06975017800338417784e-01, /* 0x3FCA7E28, 0x4A454EEF */
-	P1   =  1.66666666666666019037e-01, /* 0x3FC55555, 0x5555553E */
-	P2   = -2.77777777770155933842e-03, /* 0xBF66C16C, 0x16BEBD93 */
-	P3   =  6.61375632143793436117e-05, /* 0x3F11566A, 0xAF25DE2C */
-	P4   = -1.65339022054652515390e-06, /* 0xBEBBBD41, 0xC5D26BF1 */
-	P5   =  4.13813679705723846039e-08, /* 0x3E663769, 0x72BEA4D0 */
-	lg2  =  6.93147180559945286227e-01, /* 0x3FE62E42, 0xFEFA39EF */
-	lg2_h  =  6.93147182464599609375e-01, /* 0x3FE62E43, 0x00000000 */
-	lg2_l  = -1.90465429995776804525e-09, /* 0xBE205C61, 0x0CA86C39 */
-	ovt =  8.0085662595372944372e-0017, /* -(1024-log2(ovfl+.5ulp)) */
-	cp    =  9.61796693925975554329e-01, /* 0x3FEEC709, 0xDC3A03FD =2/(3ln2) */
-	cp_h  =  9.61796700954437255859e-01, /* 0x3FEEC709, 0xE0000000 =(float)cp */
-	cp_l  = -7.02846165095275826516e-09, /* 0xBE3E2FE0, 0x145B01F5 =tail of cp_h*/
-	ivln2    =  1.44269504088896338700e+00, /* 0x3FF71547, 0x652B82FE =1/ln2 */
-	ivln2_h  =  1.44269502162933349609e+00, /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
-	ivln2_l  =  1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
+		L1 = 5.99999999999994648725e-01,	  /* 0x3FE33333, 0x33333303 */
+		L2 = 4.28571428578550184252e-01,	  /* 0x3FDB6DB6, 0xDB6FABFF */
+		L3 = 3.33333329818377432918e-01,	  /* 0x3FD55555, 0x518F264D */
+		L4 = 2.72728123808534006489e-01,	  /* 0x3FD17460, 0xA91D4101 */
+		L5 = 2.30660745775561754067e-01,	  /* 0x3FCD864A, 0x93C9DB65 */
+		L6 = 2.06975017800338417784e-01,	  /* 0x3FCA7E28, 0x4A454EEF */
+		P1 = 1.66666666666666019037e-01,	  /* 0x3FC55555, 0x5555553E */
+		P2 = -2.77777777770155933842e-03,	  /* 0xBF66C16C, 0x16BEBD93 */
+		P3 = 6.61375632143793436117e-05,	  /* 0x3F11566A, 0xAF25DE2C */
+		P4 = -1.65339022054652515390e-06,	  /* 0xBEBBBD41, 0xC5D26BF1 */
+		P5 = 4.13813679705723846039e-08,	  /* 0x3E663769, 0x72BEA4D0 */
+		lg2 = 6.93147180559945286227e-01,	  /* 0x3FE62E42, 0xFEFA39EF */
+		lg2_h = 6.93147182464599609375e-01,	  /* 0x3FE62E43, 0x00000000 */
+		lg2_l = -1.90465429995776804525e-09,  /* 0xBE205C61, 0x0CA86C39 */
+		ovt = 8.0085662595372944372e-0017,	  /* -(1024-log2(ovfl+.5ulp)) */
+		cp = 9.61796693925975554329e-01,	  /* 0x3FEEC709, 0xDC3A03FD =2/(3ln2) */
+		cp_h = 9.61796700954437255859e-01,	  /* 0x3FEEC709, 0xE0000000 =(float)cp */
+		cp_l = -7.02846165095275826516e-09,	  /* 0xBE3E2FE0, 0x145B01F5 =tail of cp_h*/
+		ivln2 = 1.44269504088896338700e+00,	  /* 0x3FF71547, 0x652B82FE =1/ln2 */
+		ivln2_h = 1.44269502162933349609e+00, /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
+		ivln2_l = 1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
 
-	double z,ax,z_h,z_l,p_h,p_l;
-	double y1,t1,t2,r,s,t,u,v,w;
-	int i0,i1,i,j,k,yisint,n;
-	int hx,hy,ix,iy;
-	unsigned lx,ly;
+	double z, ax, z_h, z_l, p_h, p_l;
+	double y1, t1, t2, r, s, t, u, v, w;
+	int i0, i1, i, j, k, yisint, n;
+	int hx, hy, ix, iy;
+	unsigned lx, ly;
 
-	i0 = ((*(int*)&one)>>29)^1; i1=1-i0;
-	hx = __HI(x); lx = __LO(x);
-	hy = __HI(y); ly = __LO(y);
-	ix = hx&0x7fffffff;  iy = hy&0x7fffffff;
+	i0 = ((*(int *)&one) >> 29) ^ 1;
+	i1 = 1 - i0;
+	hx = __HI(x);
+	lx = __LO(x);
+	hy = __HI(y);
+	ly = __LO(y);
+	ix = hx & 0x7fffffff;
+	iy = hy & 0x7fffffff;
 
-    /* y==zero: x**0 = 1 */
-	if((iy|ly)==0) return one; 	
+	/* y==zero: x**0 = 1 */
+	if ((iy | ly) == 0)
+		return one;
 
-    /* +-NaN return x+y */
-	if(ix > 0x7ff00000 || ((ix==0x7ff00000)&&(lx!=0)) ||
-	   iy > 0x7ff00000 || ((iy==0x7ff00000)&&(ly!=0))) 
-		return x+y;	
+	/* +-NaN return x+y */
+	if (ix > 0x7ff00000 || ((ix == 0x7ff00000) && (lx != 0)) ||
+		iy > 0x7ff00000 || ((iy == 0x7ff00000) && (ly != 0)))
+		return x + y;
 
-    /* determine if y is an odd int when x < 0
-     * yisint = 0	... y is not an integer
-     * yisint = 1	... y is an odd int
-     * yisint = 2	... y is an even int
-     */
-	yisint  = 0;
-	if(hx<0) {	
-	    if(iy>=0x43400000) yisint = 2; /* even integer y */
-	    else if(iy>=0x3ff00000) {
-		k = (iy>>20)-0x3ff;	   /* exponent */
-		if(k>20) {
-		    j = ly>>(52-k);
-		    if((j<<(52-k))==ly) yisint = 2-(j&1);
-		} else if(ly==0) {
-		    j = iy>>(20-k);
-		    if((j<<(20-k))==iy) yisint = 2-(j&1);
+	/* determine if y is an odd int when x < 0
+	 * yisint = 0	... y is not an integer
+	 * yisint = 1	... y is an odd int
+	 * yisint = 2	... y is an even int
+	 */
+	yisint = 0;
+	if (hx < 0)
+	{
+		if (iy >= 0x43400000)
+			yisint = 2; /* even integer y */
+		else if (iy >= 0x3ff00000)
+		{
+			k = (iy >> 20) - 0x3ff; /* exponent */
+			if (k > 20)
+			{
+				j = ly >> (52 - k);
+				if ((j << (52 - k)) == ly)
+					yisint = 2 - (j & 1);
+			}
+			else if (ly == 0)
+			{
+				j = iy >> (20 - k);
+				if ((j << (20 - k)) == iy)
+					yisint = 2 - (j & 1);
+			}
 		}
-	    }		
-	} 
-
-    /* special value of y */
-	if(ly==0) { 	
-	    if (iy==0x7ff00000) {	/* y is +-inf */
-	        if(((ix-0x3ff00000)|lx)==0)
-		    return  y - y;	/* inf**+-1 is NaN */
-	        else if (ix >= 0x3ff00000)/* (|x|>1)**+-inf = inf,0 */
-		    return (hy>=0)? y: zero;
-	        else			/* (|x|<1)**-,+inf = inf,0 */
-		    return (hy<0)?-y: zero;
-	    } 
-	    if(iy==0x3ff00000) {	/* y is  +-1 */
-		if(hy<0) return one/x; else return x;
-	    }
-	    if(hy==0x40000000) return x*x; /* y is  2 */
-	    if(hy==0x3fe00000) {	/* y is  0.5 */
-		if(hx>=0)	/* x >= +0 */
-		return fdlibm_sqrt(x);	
-	    }
 	}
 
-	ax   = fdlibm_fabs(x);
-    /* special value of x */
-	if(lx==0) {
-	    if(ix==0x7ff00000||ix==0||ix==0x3ff00000){
-		z = ax;			/*x is +-0,+-inf,+-1*/
-		if(hy<0) z = one/z;	/* z = (1/|x|) */
-		if(hx<0) {
-		    if(((ix-0x3ff00000)|yisint)==0) {
-			z = (z-z)/(z-z); /* (-1)**non-int is NaN */
-		    } else if(yisint==1) 
-			z = -z;		/* (x<0)**odd = -(|x|**odd) */
+	/* special value of y */
+	if (ly == 0)
+	{
+		if (iy == 0x7ff00000)
+		{ /* y is +-inf */
+			if (((ix - 0x3ff00000) | lx) == 0)
+				return y - y;		   /* inf**+-1 is NaN */
+			else if (ix >= 0x3ff00000) /* (|x|>1)**+-inf = inf,0 */
+				return (hy >= 0) ? y : zero;
+			else /* (|x|<1)**-,+inf = inf,0 */
+				return (hy < 0) ? -y : zero;
 		}
-		return z;
-	    }
+		if (iy == 0x3ff00000)
+		{ /* y is  +-1 */
+			if (hy < 0)
+				return one / x;
+			else
+				return x;
+		}
+		if (hy == 0x40000000)
+			return x * x; /* y is  2 */
+		if (hy == 0x3fe00000)
+		{				 /* y is  0.5 */
+			if (hx >= 0) /* x >= +0 */
+				return fdlibm_sqrt(x);
+		}
 	}
-    
-	n = (hx>>31)+1;
 
-    /* (x<0)**(non-int) is NaN */
-	if((n|yisint)==0) return (x-x)/(x-x);
+	ax = fdlibm_fabs(x);
+	/* special value of x */
+	if (lx == 0)
+	{
+		if (ix == 0x7ff00000 || ix == 0 || ix == 0x3ff00000)
+		{
+			z = ax; /*x is +-0,+-inf,+-1*/
+			if (hy < 0)
+				z = one / z; /* z = (1/|x|) */
+			if (hx < 0)
+			{
+				if (((ix - 0x3ff00000) | yisint) == 0)
+				{
+					z = (z - z) / (z - z); /* (-1)**non-int is NaN */
+				}
+				else if (yisint == 1)
+					z = -z; /* (x<0)**odd = -(|x|**odd) */
+			}
+			return z;
+		}
+	}
+
+	n = (hx >> 31) + 1;
+
+	/* (x<0)**(non-int) is NaN */
+	if ((n | yisint) == 0)
+		return (x - x) / (x - x);
 
 	s = one; /* s (sign of result -ve**odd) = -1 else = 1 */
-	if((n|(yisint-1))==0) s = -one;/* (-ve)**(odd int) */
+	if ((n | (yisint - 1)) == 0)
+		s = -one; /* (-ve)**(odd int) */
 
-    /* |y| is huge */
-	if(iy>0x41e00000) { /* if |y| > 2**31 */
-	    if(iy>0x43f00000){	/* if |y| > 2**64, must o/uflow */
-		if(ix<=0x3fefffff) return (hy<0)? huge*huge:tiny*tiny;
-		if(ix>=0x3ff00000) return (hy>0)? huge*huge:tiny*tiny;
-	    }
-	/* over/underflow if x is not close to one */
-	    if(ix<0x3fefffff) return (hy<0)? s*huge*huge:s*tiny*tiny;
-	    if(ix>0x3ff00000) return (hy>0)? s*huge*huge:s*tiny*tiny;
-	/* now |1-x| is tiny <= 2**-20, suffice to compute 
-	   log(x) by x-x^2/2+x^3/3-x^4/4 */
-	    t = ax-one;		/* t has 20 trailing zeros */
-	    w = (t*t)*(0.5-t*(0.3333333333333333333333-t*0.25));
-	    u = ivln2_h*t;	/* ivln2_h has 21 sig. bits */
-	    v = t*ivln2_l-w*ivln2;
-	    t1 = u+v;
-	    __LO(t1) = 0;
-	    t2 = v-(t1-u);
-	} else {
-	    double ss,s2,s_h,s_l,t_h,t_l;
-	    n = 0;
-	/* take care subnormal number */
-	    if(ix<0x00100000)
-		{ax *= two53; n -= 53; ix = __HI(ax); }
-	    n  += ((ix)>>20)-0x3ff;
-	    j  = ix&0x000fffff;
-	/* determine interval */
-	    ix = j|0x3ff00000;		/* normalize ix */
-	    if(j<=0x3988E) k=0;		/* |x|<sqrt(3/2) */
-	    else if(j<0xBB67A) k=1;	/* |x|<sqrt(3)   */
-	    else {k=0;n+=1;ix -= 0x00100000;}
-	    __HI(ax) = ix;
+	/* |y| is huge */
+	if (iy > 0x41e00000)
+	{ /* if |y| > 2**31 */
+		if (iy > 0x43f00000)
+		{ /* if |y| > 2**64, must o/uflow */
+			if (ix <= 0x3fefffff)
+				return (hy < 0) ? huge * huge : tiny * tiny;
+			if (ix >= 0x3ff00000)
+				return (hy > 0) ? huge * huge : tiny * tiny;
+		}
+		/* over/underflow if x is not close to one */
+		if (ix < 0x3fefffff)
+			return (hy < 0) ? s * huge * huge : s * tiny * tiny;
+		if (ix > 0x3ff00000)
+			return (hy > 0) ? s * huge * huge : s * tiny * tiny;
+		/* now |1-x| is tiny <= 2**-20, suffice to compute
+		   log(x) by x-x^2/2+x^3/3-x^4/4 */
+		t = ax - one; /* t has 20 trailing zeros */
+		w = (t * t) * (0.5 - t * (0.3333333333333333333333 - t * 0.25));
+		u = ivln2_h * t; /* ivln2_h has 21 sig. bits */
+		v = t * ivln2_l - w * ivln2;
+		t1 = u + v;
+		__LO(t1) = 0;
+		t2 = v - (t1 - u);
+	}
+	else
+	{
+		double ss, s2, s_h, s_l, t_h, t_l;
+		n = 0;
+		/* take care subnormal number */
+		if (ix < 0x00100000)
+		{
+			ax *= two53;
+			n -= 53;
+			ix = __HI(ax);
+		}
+		n += ((ix) >> 20) - 0x3ff;
+		j = ix & 0x000fffff;
+		/* determine interval */
+		ix = j | 0x3ff00000; /* normalize ix */
+		if (j <= 0x3988E)
+			k = 0; /* |x|<sqrt(3/2) */
+		else if (j < 0xBB67A)
+			k = 1; /* |x|<sqrt(3)   */
+		else
+		{
+			k = 0;
+			n += 1;
+			ix -= 0x00100000;
+		}
+		__HI(ax) = ix;
 
-	/* compute ss = s_h+s_l = (x-1)/(x+1) or (x-1.5)/(x+1.5) */
-	    u = ax-bp[k];		/* bp[0]=1.0, bp[1]=1.5 */
-	    v = one/(ax+bp[k]);
-	    ss = u*v;
-	    s_h = ss;
-	    __LO(s_h) = 0;
-	/* t_h=ax+bp[k] High */
-	    t_h = zero;
-	    __HI(t_h)=((ix>>1)|0x20000000)+0x00080000+(k<<18); 
-	    t_l = ax - (t_h-bp[k]);
-	    s_l = v*((u-s_h*t_h)-s_h*t_l);
-	/* compute log(ax) */
-	    s2 = ss*ss;
-	    r = s2*s2*(L1+s2*(L2+s2*(L3+s2*(L4+s2*(L5+s2*L6)))));
-	    r += s_l*(s_h+ss);
-	    s2  = s_h*s_h;
-	    t_h = 3.0+s2+r;
-	    __LO(t_h) = 0;
-	    t_l = r-((t_h-3.0)-s2);
-	/* u+v = ss*(1+...) */
-	    u = s_h*t_h;
-	    v = s_l*t_h+t_l*ss;
-	/* 2/(3log2)*(ss+...) */
-	    p_h = u+v;
-	    __LO(p_h) = 0;
-	    p_l = v-(p_h-u);
-	    z_h = cp_h*p_h;		/* cp_h+cp_l = 2/(3*log2) */
-	    z_l = cp_l*p_h+p_l*cp+dp_l[k];
-	/* log2(ax) = (ss+..)*2/(3*log2) = n + dp_h + z_h + z_l */
-	    t = (double)n;
-	    t1 = (((z_h+z_l)+dp_h[k])+t);
-	    __LO(t1) = 0;
-	    t2 = z_l-(((t1-t)-dp_h[k])-z_h);
+		/* compute ss = s_h+s_l = (x-1)/(x+1) or (x-1.5)/(x+1.5) */
+		u = ax - bp[k]; /* bp[0]=1.0, bp[1]=1.5 */
+		v = one / (ax + bp[k]);
+		ss = u * v;
+		s_h = ss;
+		__LO(s_h) = 0;
+		/* t_h=ax+bp[k] High */
+		t_h = zero;
+		__HI(t_h) = ((ix >> 1) | 0x20000000) + 0x00080000 + (k << 18);
+		t_l = ax - (t_h - bp[k]);
+		s_l = v * ((u - s_h * t_h) - s_h * t_l);
+		/* compute log(ax) */
+		s2 = ss * ss;
+		r = s2 * s2 * (L1 + s2 * (L2 + s2 * (L3 + s2 * (L4 + s2 * (L5 + s2 * L6)))));
+		r += s_l * (s_h + ss);
+		s2 = s_h * s_h;
+		t_h = 3.0 + s2 + r;
+		__LO(t_h) = 0;
+		t_l = r - ((t_h - 3.0) - s2);
+		/* u+v = ss*(1+...) */
+		u = s_h * t_h;
+		v = s_l * t_h + t_l * ss;
+		/* 2/(3log2)*(ss+...) */
+		p_h = u + v;
+		__LO(p_h) = 0;
+		p_l = v - (p_h - u);
+		z_h = cp_h * p_h; /* cp_h+cp_l = 2/(3*log2) */
+		z_l = cp_l * p_h + p_l * cp + dp_l[k];
+		/* log2(ax) = (ss+..)*2/(3*log2) = n + dp_h + z_h + z_l */
+		t = (double)n;
+		t1 = (((z_h + z_l) + dp_h[k]) + t);
+		__LO(t1) = 0;
+		t2 = z_l - (((t1 - t) - dp_h[k]) - z_h);
 	}
 
-    /* split up y into y1+y2 and compute (y1+y2)*(t1+t2) */
-	y1  = y;
+	/* split up y into y1+y2 and compute (y1+y2)*(t1+t2) */
+	y1 = y;
 	__LO(y1) = 0;
-	p_l = (y-y1)*t1+y*t2;
-	p_h = y1*t1;
-	z = p_l+p_h;
+	p_l = (y - y1) * t1 + y * t2;
+	p_h = y1 * t1;
+	z = p_l + p_h;
 	j = __HI(z);
 	i = __LO(z);
-	if (j>=0x40900000) {				/* z >= 1024 */
-	    if(((j-0x40900000)|i)!=0)			/* if z > 1024 */
-		return s*huge*huge;			/* overflow */
-	    else {
-		if(p_l+ovt>z-p_h) return s*huge*huge;	/* overflow */
-	    }
-	} else if((j&0x7fffffff)>=0x4090cc00 ) {	/* z <= -1075 */
-	    if(((j-0xc090cc00)|i)!=0) 		/* z < -1075 */
-		return s*tiny*tiny;		/* underflow */
-	    else {
-		if(p_l<=z-p_h) return s*tiny*tiny;	/* underflow */
-	    }
+	if (j >= 0x40900000)
+	{									 /* z >= 1024 */
+		if (((j - 0x40900000) | i) != 0) /* if z > 1024 */
+			return s * huge * huge;		 /* overflow */
+		else
+		{
+			if (p_l + ovt > z - p_h)
+				return s * huge * huge; /* overflow */
+		}
 	}
-    /*
-     * compute 2**(p_h+p_l)
-     */
-	i = j&0x7fffffff;
-	k = (i>>20)-0x3ff;
+	else if ((j & 0x7fffffff) >= 0x4090cc00)
+	{									 /* z <= -1075 */
+		if (((j - 0xc090cc00) | i) != 0) /* z < -1075 */
+			return s * tiny * tiny;		 /* underflow */
+		else
+		{
+			if (p_l <= z - p_h)
+				return s * tiny * tiny; /* underflow */
+		}
+	}
+	/*
+	 * compute 2**(p_h+p_l)
+	 */
+	i = j & 0x7fffffff;
+	k = (i >> 20) - 0x3ff;
 	n = 0;
-	if(i>0x3fe00000) {		/* if |z| > 0.5, set n = [z+0.5] */
-	    n = j+(0x00100000>>(k+1));
-	    k = ((n&0x7fffffff)>>20)-0x3ff;	/* new k for n */
-	    t = zero;
-	    __HI(t) = (n&~(0x000fffff>>k));
-	    n = ((n&0x000fffff)|0x00100000)>>(20-k);
-	    if(j<0) n = -n;
-	    p_h -= t;
-	} 
-	t = p_l+p_h;
+	if (i > 0x3fe00000)
+	{ /* if |z| > 0.5, set n = [z+0.5] */
+		n = j + (0x00100000 >> (k + 1));
+		k = ((n & 0x7fffffff) >> 20) - 0x3ff; /* new k for n */
+		t = zero;
+		__HI(t) = (n & ~(0x000fffff >> k));
+		n = ((n & 0x000fffff) | 0x00100000) >> (20 - k);
+		if (j < 0)
+			n = -n;
+		p_h -= t;
+	}
+	t = p_l + p_h;
 	__LO(t) = 0;
-	u = t*lg2_h;
-	v = (p_l-(t-p_h))*lg2+t*lg2_l;
-	z = u+v;
-	w = v-(z-u);
-	t  = z*z;
-	t1  = z - t*(P1+t*(P2+t*(P3+t*(P4+t*P5))));
-	r  = (z*t1)/(t1-two)-(w+z*w);
-	z  = one-(r-z);
-	j  = __HI(z);
-	j += (n<<20);
-	if((j>>20)<=0) z = fdlibm_scalbn(z,n);	/* subnormal output */
-	else __HI(z) += (n<<20);
-	return s*z;
+	u = t * lg2_h;
+	v = (p_l - (t - p_h)) * lg2 + t * lg2_l;
+	z = u + v;
+	w = v - (z - u);
+	t = z * z;
+	t1 = z - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
+	r = (z * t1) / (t1 - two) - (w + z * w);
+	z = one - (r - z);
+	j = __HI(z);
+	j += (n << 20);
+	if ((j >> 20) <= 0)
+		z = fdlibm_scalbn(z, n); /* subnormal output */
+	else
+		__HI(z) += (n << 20);
+	return s * z;
 }
 
 static double __ieee754_atan2(double y, double x)
-{  
-	static const double 
-		tiny  = 1.0e-300,
-		zero  = 0.0,
-		pi_o_4  = 7.8539816339744827900E-01, /* 0x3FE921FB, 0x54442D18 */
-		pi_o_2  = 1.5707963267948965580E+00, /* 0x3FF921FB, 0x54442D18 */
-		pi      = 3.1415926535897931160E+00, /* 0x400921FB, 0x54442D18 */
-		pi_lo   = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
+{
+	static const double
+		tiny = 1.0e-300,
+		zero = 0.0,
+		pi_o_4 = 7.8539816339744827900E-01, /* 0x3FE921FB, 0x54442D18 */
+		pi_o_2 = 1.5707963267948965580E+00, /* 0x3FF921FB, 0x54442D18 */
+		pi = 3.1415926535897931160E+00,		/* 0x400921FB, 0x54442D18 */
+		pi_lo = 1.2246467991473531772E-16;	/* 0x3CA1A626, 0x33145C07 */
 
 	double z;
-	int k,m,hx,hy,ix,iy;
-	unsigned lx,ly;
+	int k, m, hx, hy, ix, iy;
+	unsigned lx, ly;
 
-	hx = __HI(x); ix = hx&0x7fffffff;
+	hx = __HI(x);
+	ix = hx & 0x7fffffff;
 	lx = __LO(x);
-	hy = __HI(y); iy = hy&0x7fffffff;
+	hy = __HI(y);
+	iy = hy & 0x7fffffff;
 	ly = __LO(y);
-	if(((ix|((lx|(unsigned)-(int)lx)>>31))>0x7ff00000)||
-	   ((iy|((ly|(unsigned)-(int)ly)>>31))>0x7ff00000))	/* x or y is NaN */
-	   return x+y;
-	if((hx-0x3ff00000|lx)==0) return fdlibm_atan(y);   /* x=1.0 */
-	m = ((hy>>31)&1)|((hx>>30)&2);	/* 2*sign(x)+sign(y) */
+	if (((ix | ((lx | (unsigned)-(int)lx) >> 31)) > 0x7ff00000) ||
+		((iy | ((ly | (unsigned)-(int)ly) >> 31)) > 0x7ff00000)) /* x or y is NaN */
+		return x + y;
+	if ((hx - 0x3ff00000 | lx) == 0)
+		return fdlibm_atan(y);				 /* x=1.0 */
+	m = ((hy >> 31) & 1) | ((hx >> 30) & 2); /* 2*sign(x)+sign(y) */
 
-    /* when y = 0 */
-	if((iy|ly)==0) {
-	    switch(m) {
-		case 0: 
-		case 1: return y; 	/* atan(+-0,+anything)=+-0 */
-		case 2: return  pi+tiny;/* atan(+0,-anything) = pi */
-		case 3: return -pi-tiny;/* atan(-0,-anything) =-pi */
-	    }
-	}
-    /* when x = 0 */
-	if((ix|lx)==0) return (hy<0)?  -pi_o_2-tiny: pi_o_2+tiny;
-	    
-    /* when x is INF */
-	if(ix==0x7ff00000) {
-	    if(iy==0x7ff00000) {
-		switch(m) {
-		    case 0: return  pi_o_4+tiny;/* atan(+INF,+INF) */
-		    case 1: return -pi_o_4-tiny;/* atan(-INF,+INF) */
-		    case 2: return  3.0*pi_o_4+tiny;/*atan(+INF,-INF)*/
-		    case 3: return -3.0*pi_o_4-tiny;/*atan(-INF,-INF)*/
+	/* when y = 0 */
+	if ((iy | ly) == 0)
+	{
+		switch (m)
+		{
+		case 0:
+		case 1:
+			return y; /* atan(+-0,+anything)=+-0 */
+		case 2:
+			return pi + tiny; /* atan(+0,-anything) = pi */
+		case 3:
+			return -pi - tiny; /* atan(-0,-anything) =-pi */
 		}
-	    } else {
-		switch(m) {
-		    case 0: return  zero  ;	/* atan(+...,+INF) */
-		    case 1: return -zero  ;	/* atan(-...,+INF) */
-		    case 2: return  pi+tiny  ;	/* atan(+...,-INF) */
-		    case 3: return -pi-tiny  ;	/* atan(-...,-INF) */
-		}
-	    }
 	}
-    /* when y is INF */
-	if(iy==0x7ff00000) return (hy<0)? -pi_o_2-tiny: pi_o_2+tiny;
+	/* when x = 0 */
+	if ((ix | lx) == 0)
+		return (hy < 0) ? -pi_o_2 - tiny : pi_o_2 + tiny;
 
-    /* compute y/x */
-	k = (iy-ix)>>20;
-	if(k > 60) z=pi_o_2+0.5*pi_lo; 	/* |y/x| >  2**60 */
-	else if(hx<0&&k<-60) z=0.0; 	/* |y|/x < -2**60 */
-	else z=fdlibm_atan(fdlibm_fabs(y/x));		/* safe to do y/x */
-	switch (m) {
-	    case 0: return       z  ;	/* atan(+,+) */
-	    case 1: __HI(z) ^= 0x80000000;
-		    return       z  ;	/* atan(-,+) */
-	    case 2: return  pi-(z-pi_lo);/* atan(+,-) */
-	    default: /* case 3 */
-	    	    return  (z-pi_lo)-pi;/* atan(-,-) */
+	/* when x is INF */
+	if (ix == 0x7ff00000)
+	{
+		if (iy == 0x7ff00000)
+		{
+			switch (m)
+			{
+			case 0:
+				return pi_o_4 + tiny; /* atan(+INF,+INF) */
+			case 1:
+				return -pi_o_4 - tiny; /* atan(-INF,+INF) */
+			case 2:
+				return 3.0 * pi_o_4 + tiny; /*atan(+INF,-INF)*/
+			case 3:
+				return -3.0 * pi_o_4 - tiny; /*atan(-INF,-INF)*/
+			}
+		}
+		else
+		{
+			switch (m)
+			{
+			case 0:
+				return zero; /* atan(+...,+INF) */
+			case 1:
+				return -zero; /* atan(-...,+INF) */
+			case 2:
+				return pi + tiny; /* atan(+...,-INF) */
+			case 3:
+				return -pi - tiny; /* atan(-...,-INF) */
+			}
+		}
+	}
+	/* when y is INF */
+	if (iy == 0x7ff00000)
+		return (hy < 0) ? -pi_o_2 - tiny : pi_o_2 + tiny;
+
+	/* compute y/x */
+	k = (iy - ix) >> 20;
+	if (k > 60)
+		z = pi_o_2 + 0.5 * pi_lo; /* |y/x| >  2**60 */
+	else if (hx < 0 && k < -60)
+		z = 0.0; /* |y|/x < -2**60 */
+	else
+		z = fdlibm_atan(fdlibm_fabs(y / x)); /* safe to do y/x */
+	switch (m)
+	{
+	case 0:
+		return z; /* atan(+,+) */
+	case 1:
+		__HI(z) ^= 0x80000000;
+		return z; /* atan(-,+) */
+	case 2:
+		return pi - (z - pi_lo); /* atan(+,-) */
+	default:					 /* case 3 */
+		return (z - pi_lo) - pi; /* atan(-,-) */
 	}
 }
 
 static double __ieee754_asin(double x)
 {
-	static const double 
-		one =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
-		huge =  1.000e+300,
-		pio2_hi =  1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
-		pio2_lo =  6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
-		pio4_hi =  7.85398163397448278999e-01, /* 0x3FE921FB, 0x54442D18 */
-			/* coefficient for R(x^2) */
-		pS0 =  1.66666666666666657415e-01, /* 0x3FC55555, 0x55555555 */
-		pS1 = -3.25565818622400915405e-01, /* 0xBFD4D612, 0x03EB6F7D */
-		pS2 =  2.01212532134862925881e-01, /* 0x3FC9C155, 0x0E884455 */
-		pS3 = -4.00555345006794114027e-02, /* 0xBFA48228, 0xB5688F3B */
-		pS4 =  7.91534994289814532176e-04, /* 0x3F49EFE0, 0x7501B288 */
-		pS5 =  3.47933107596021167570e-05, /* 0x3F023DE1, 0x0DFDF709 */
-		qS1 = -2.40339491173441421878e+00, /* 0xC0033A27, 0x1C8A2D4B */
-		qS2 =  2.02094576023350569471e+00, /* 0x40002AE5, 0x9C598AC8 */
-		qS3 = -6.88283971605453293030e-01, /* 0xBFE6066C, 0x1B8D0159 */
-		qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+	static const double
+		one = 1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+		huge = 1.000e+300,
+		pio2_hi = 1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
+		pio2_lo = 6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
+		pio4_hi = 7.85398163397448278999e-01, /* 0x3FE921FB, 0x54442D18 */
+											  /* coefficient for R(x^2) */
+		pS0 = 1.66666666666666657415e-01,	  /* 0x3FC55555, 0x55555555 */
+		pS1 = -3.25565818622400915405e-01,	  /* 0xBFD4D612, 0x03EB6F7D */
+		pS2 = 2.01212532134862925881e-01,	  /* 0x3FC9C155, 0x0E884455 */
+		pS3 = -4.00555345006794114027e-02,	  /* 0xBFA48228, 0xB5688F3B */
+		pS4 = 7.91534994289814532176e-04,	  /* 0x3F49EFE0, 0x7501B288 */
+		pS5 = 3.47933107596021167570e-05,	  /* 0x3F023DE1, 0x0DFDF709 */
+		qS1 = -2.40339491173441421878e+00,	  /* 0xC0033A27, 0x1C8A2D4B */
+		qS2 = 2.02094576023350569471e+00,	  /* 0x40002AE5, 0x9C598AC8 */
+		qS3 = -6.88283971605453293030e-01,	  /* 0xBFE6066C, 0x1B8D0159 */
+		qS4 = 7.70381505559019352791e-02;	  /* 0x3FB3B8C5, 0xB12E9282 */
 
-	double t,w,p,q,c,r,s;
-	int hx,ix;
+	double t, w, p, q, c, r, s;
+	int hx, ix;
 	hx = __HI(x);
-	ix = hx&0x7fffffff;
-	if(ix>= 0x3ff00000) {		/* |x|>= 1 */
-	    if(((ix-0x3ff00000)|__LO(x))==0)
-		    /* asin(1)=+-pi/2 with inexact */
-		return x*pio2_hi+x*pio2_lo;	
-	    return (x-x)/(x-x);		/* asin(|x|>1) is NaN */   
-	} else if (ix<0x3fe00000) {	/* |x|<0.5 */
-	    if(ix<0x3e400000) {		/* if |x| < 2**-27 */
-		if(huge+x>one) return x;/* return x with inexact if x!=0*/
-	    } else 
-		t = x*x;
-		p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
-		q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
-		w = p/q;
-		return x+x*w;
+	ix = hx & 0x7fffffff;
+	if (ix >= 0x3ff00000)
+	{ /* |x|>= 1 */
+		if (((ix - 0x3ff00000) | __LO(x)) == 0)
+			/* asin(1)=+-pi/2 with inexact */
+			return x * pio2_hi + x * pio2_lo;
+		return (x - x) / (x - x); /* asin(|x|>1) is NaN */
+	}
+	else if (ix < 0x3fe00000)
+	{ /* |x|<0.5 */
+		if (ix < 0x3e400000)
+		{ /* if |x| < 2**-27 */
+			if (huge + x > one)
+				return x; /* return x with inexact if x!=0*/
+		}
+		else
+			t = x * x;
+		p = t * (pS0 + t * (pS1 + t * (pS2 + t * (pS3 + t * (pS4 + t * pS5)))));
+		q = one + t * (qS1 + t * (qS2 + t * (qS3 + t * qS4)));
+		w = p / q;
+		return x + x * w;
 	}
 	/* 1> |x|>= 0.5 */
-	w = one-fdlibm_fabs(x);
-	t = w*0.5;
-	p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
-	q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
+	w = one - fdlibm_fabs(x);
+	t = w * 0.5;
+	p = t * (pS0 + t * (pS1 + t * (pS2 + t * (pS3 + t * (pS4 + t * pS5)))));
+	q = one + t * (qS1 + t * (qS2 + t * (qS3 + t * qS4)));
 	s = fdlibm_sqrt(t);
-	if(ix>=0x3FEF3333) { 	/* if |x| > 0.975 */
-	    w = p/q;
-	    t = pio2_hi-(2.0*(s+s*w)-pio2_lo);
-	} else {
-	    w  = s;
-	    __LO(w) = 0;
-	    c  = (t-w*w)/(s+w);
-	    r  = p/q;
-	    p  = 2.0*s*r-(pio2_lo-2.0*c);
-	    q  = pio4_hi-2.0*w;
-	    t  = pio4_hi-(p-q);
-	}    
-	if(hx>0) return t; else return -t;    
+	if (ix >= 0x3FEF3333)
+	{ /* if |x| > 0.975 */
+		w = p / q;
+		t = pio2_hi - (2.0 * (s + s * w) - pio2_lo);
+	}
+	else
+	{
+		w = s;
+		__LO(w) = 0;
+		c = (t - w * w) / (s + w);
+		r = p / q;
+		p = 2.0 * s * r - (pio2_lo - 2.0 * c);
+		q = pio4_hi - 2.0 * w;
+		t = pio4_hi - (p - q);
+	}
+	if (hx > 0)
+		return t;
+	else
+		return -t;
 }
 
 static double __ieee754_acos(double x)
 {
-	static const double 
-		one=  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
-		pi =  3.14159265358979311600e+00, /* 0x400921FB, 0x54442D18 */
-		pio2_hi =  1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
-		pio2_lo =  6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
-		pS0 =  1.66666666666666657415e-01, /* 0x3FC55555, 0x55555555 */
-		pS1 = -3.25565818622400915405e-01, /* 0xBFD4D612, 0x03EB6F7D */
-		pS2 =  2.01212532134862925881e-01, /* 0x3FC9C155, 0x0E884455 */
-		pS3 = -4.00555345006794114027e-02, /* 0xBFA48228, 0xB5688F3B */
-		pS4 =  7.91534994289814532176e-04, /* 0x3F49EFE0, 0x7501B288 */
-		pS5 =  3.47933107596021167570e-05, /* 0x3F023DE1, 0x0DFDF709 */
-		qS1 = -2.40339491173441421878e+00, /* 0xC0033A27, 0x1C8A2D4B */
-		qS2 =  2.02094576023350569471e+00, /* 0x40002AE5, 0x9C598AC8 */
-		qS3 = -6.88283971605453293030e-01, /* 0xBFE6066C, 0x1B8D0159 */
-		qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+	static const double
+		one = 1.00000000000000000000e+00,	  /* 0x3FF00000, 0x00000000 */
+		pi = 3.14159265358979311600e+00,	  /* 0x400921FB, 0x54442D18 */
+		pio2_hi = 1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
+		pio2_lo = 6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
+		pS0 = 1.66666666666666657415e-01,	  /* 0x3FC55555, 0x55555555 */
+		pS1 = -3.25565818622400915405e-01,	  /* 0xBFD4D612, 0x03EB6F7D */
+		pS2 = 2.01212532134862925881e-01,	  /* 0x3FC9C155, 0x0E884455 */
+		pS3 = -4.00555345006794114027e-02,	  /* 0xBFA48228, 0xB5688F3B */
+		pS4 = 7.91534994289814532176e-04,	  /* 0x3F49EFE0, 0x7501B288 */
+		pS5 = 3.47933107596021167570e-05,	  /* 0x3F023DE1, 0x0DFDF709 */
+		qS1 = -2.40339491173441421878e+00,	  /* 0xC0033A27, 0x1C8A2D4B */
+		qS2 = 2.02094576023350569471e+00,	  /* 0x40002AE5, 0x9C598AC8 */
+		qS3 = -6.88283971605453293030e-01,	  /* 0xBFE6066C, 0x1B8D0159 */
+		qS4 = 7.70381505559019352791e-02;	  /* 0x3FB3B8C5, 0xB12E9282 */
 
-	double z,p,q,r,w,s,c,df;
-	int hx,ix;
+	double z, p, q, r, w, s, c, df;
+	int hx, ix;
 	hx = __HI(x);
-	ix = hx&0x7fffffff;
-	if(ix>=0x3ff00000) {	/* |x| >= 1 */
-	    if(((ix-0x3ff00000)|__LO(x))==0) {	/* |x|==1 */
-		if(hx>0) return 0.0;		/* acos(1) = 0  */
-		else return pi+2.0*pio2_lo;	/* acos(-1)= pi */
-	    }
-	    return (x-x)/(x-x);		/* acos(|x|>1) is NaN */
+	ix = hx & 0x7fffffff;
+	if (ix >= 0x3ff00000)
+	{ /* |x| >= 1 */
+		if (((ix - 0x3ff00000) | __LO(x)) == 0)
+		{ /* |x|==1 */
+			if (hx > 0)
+				return 0.0; /* acos(1) = 0  */
+			else
+				return pi + 2.0 * pio2_lo; /* acos(-1)= pi */
+		}
+		return (x - x) / (x - x); /* acos(|x|>1) is NaN */
 	}
-	if(ix<0x3fe00000) {	/* |x| < 0.5 */
-	    if(ix<=0x3c600000) return pio2_hi+pio2_lo;/*if|x|<2**-57*/
-	    z = x*x;
-	    p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
-	    q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
-	    r = p/q;
-	    return pio2_hi - (x - (pio2_lo-x*r));
-	} else  if (hx<0) {		/* x < -0.5 */
-	    z = (one+x)*0.5;
-	    p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
-	    q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
-	    s = fdlibm_sqrt(z);
-	    r = p/q;
-	    w = r*s-pio2_lo;
-	    return pi - 2.0*(s+w);
-	} else {			/* x > 0.5 */
-	    z = (one-x)*0.5;
-	    s = fdlibm_sqrt(z);
-	    df = s;
-	    __LO(df) = 0;
-	    c  = (z-df*df)/(s+df);
-	    p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
-	    q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
-	    r = p/q;
-	    w = r*s+c;
-	    return 2.0*(df+w);
+	if (ix < 0x3fe00000)
+	{ /* |x| < 0.5 */
+		if (ix <= 0x3c600000)
+			return pio2_hi + pio2_lo; /*if|x|<2**-57*/
+		z = x * x;
+		p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))));
+		q = one + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)));
+		r = p / q;
+		return pio2_hi - (x - (pio2_lo - x * r));
+	}
+	else if (hx < 0)
+	{ /* x < -0.5 */
+		z = (one + x) * 0.5;
+		p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))));
+		q = one + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)));
+		s = fdlibm_sqrt(z);
+		r = p / q;
+		w = r * s - pio2_lo;
+		return pi - 2.0 * (s + w);
+	}
+	else
+	{ /* x > 0.5 */
+		z = (one - x) * 0.5;
+		s = fdlibm_sqrt(z);
+		df = s;
+		__LO(df) = 0;
+		c = (z - df * df) / (s + df);
+		p = z * (pS0 + z * (pS1 + z * (pS2 + z * (pS3 + z * (pS4 + z * pS5)))));
+		q = one + z * (qS1 + z * (qS2 + z * (qS3 + z * qS4)));
+		r = p / q;
+		w = r * s + c;
+		return 2.0 * (df + w);
 	}
 }
 
 /*
- * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi 
+ * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi
  */
 static const int two_over_pi[] = {
-0xA2F983, 0x6E4E44, 0x1529FC, 0x2757D1, 0xF534DD, 0xC0DB62, 
-0x95993C, 0x439041, 0xFE5163, 0xABDEBB, 0xC561B7, 0x246E3A, 
-0x424DD2, 0xE00649, 0x2EEA09, 0xD1921C, 0xFE1DEB, 0x1CB129, 
-0xA73EE8, 0x8235F5, 0x2EBB44, 0x84E99C, 0x7026B4, 0x5F7E41, 
-0x3991D6, 0x398353, 0x39F49C, 0x845F8B, 0xBDF928, 0x3B1FF8, 
-0x97FFDE, 0x05980F, 0xEF2F11, 0x8B5A0A, 0x6D1F6D, 0x367ECF, 
-0x27CB09, 0xB74F46, 0x3F669E, 0x5FEA2D, 0x7527BA, 0xC7EBE5, 
-0xF17B3D, 0x0739F7, 0x8A5292, 0xEA6BFB, 0x5FB11F, 0x8D5D08, 
-0x560330, 0x46FC7B, 0x6BABF0, 0xCFBC20, 0x9AF436, 0x1DA9E3, 
-0x91615E, 0xE61B08, 0x659985, 0x5F14A0, 0x68408D, 0xFFD880, 
-0x4D7327, 0x310606, 0x1556CA, 0x73A8C9, 0x60E27B, 0xC08C6B, 
+	0xA2F983,
+	0x6E4E44,
+	0x1529FC,
+	0x2757D1,
+	0xF534DD,
+	0xC0DB62,
+	0x95993C,
+	0x439041,
+	0xFE5163,
+	0xABDEBB,
+	0xC561B7,
+	0x246E3A,
+	0x424DD2,
+	0xE00649,
+	0x2EEA09,
+	0xD1921C,
+	0xFE1DEB,
+	0x1CB129,
+	0xA73EE8,
+	0x8235F5,
+	0x2EBB44,
+	0x84E99C,
+	0x7026B4,
+	0x5F7E41,
+	0x3991D6,
+	0x398353,
+	0x39F49C,
+	0x845F8B,
+	0xBDF928,
+	0x3B1FF8,
+	0x97FFDE,
+	0x05980F,
+	0xEF2F11,
+	0x8B5A0A,
+	0x6D1F6D,
+	0x367ECF,
+	0x27CB09,
+	0xB74F46,
+	0x3F669E,
+	0x5FEA2D,
+	0x7527BA,
+	0xC7EBE5,
+	0xF17B3D,
+	0x0739F7,
+	0x8A5292,
+	0xEA6BFB,
+	0x5FB11F,
+	0x8D5D08,
+	0x560330,
+	0x46FC7B,
+	0x6BABF0,
+	0xCFBC20,
+	0x9AF436,
+	0x1DA9E3,
+	0x91615E,
+	0xE61B08,
+	0x659985,
+	0x5F14A0,
+	0x68408D,
+	0xFFD880,
+	0x4D7327,
+	0x310606,
+	0x1556CA,
+	0x73A8C9,
+	0x60E27B,
+	0xC08C6B,
 };
 
 static const int npio2_hw[] = {
-0x3FF921FB, 0x400921FB, 0x4012D97C, 0x401921FB, 0x401F6A7A, 0x4022D97C,
-0x4025FDBB, 0x402921FB, 0x402C463A, 0x402F6A7A, 0x4031475C, 0x4032D97C,
-0x40346B9C, 0x4035FDBB, 0x40378FDB, 0x403921FB, 0x403AB41B, 0x403C463A,
-0x403DD85A, 0x403F6A7A, 0x40407E4C, 0x4041475C, 0x4042106C, 0x4042D97C,
-0x4043A28C, 0x40446B9C, 0x404534AC, 0x4045FDBB, 0x4046C6CB, 0x40478FDB,
-0x404858EB, 0x404921FB,
+	0x3FF921FB,
+	0x400921FB,
+	0x4012D97C,
+	0x401921FB,
+	0x401F6A7A,
+	0x4022D97C,
+	0x4025FDBB,
+	0x402921FB,
+	0x402C463A,
+	0x402F6A7A,
+	0x4031475C,
+	0x4032D97C,
+	0x40346B9C,
+	0x4035FDBB,
+	0x40378FDB,
+	0x403921FB,
+	0x403AB41B,
+	0x403C463A,
+	0x403DD85A,
+	0x403F6A7A,
+	0x40407E4C,
+	0x4041475C,
+	0x4042106C,
+	0x4042D97C,
+	0x4043A28C,
+	0x40446B9C,
+	0x404534AC,
+	0x4045FDBB,
+	0x4046C6CB,
+	0x40478FDB,
+	0x404858EB,
+	0x404921FB,
 };
 
-static int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2) 
+static int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2)
 {
-	static const int init_jk[] = {2,3,4,6}; /* initial value for jk */
+	static const int init_jk[] = {2, 3, 4, 6}; /* initial value for jk */
 
 	static const double PIo2[] = {
-	  1.57079625129699707031e+00, /* 0x3FF921FB, 0x40000000 */
-	  7.54978941586159635335e-08, /* 0x3E74442D, 0x00000000 */
-	  5.39030252995776476554e-15, /* 0x3CF84698, 0x80000000 */
-	  3.28200341580791294123e-22, /* 0x3B78CC51, 0x60000000 */
-	  1.27065575308067607349e-29, /* 0x39F01B83, 0x80000000 */
-	  1.22933308981111328932e-36, /* 0x387A2520, 0x40000000 */
-	  2.73370053816464559624e-44, /* 0x36E38222, 0x80000000 */
-	  2.16741683877804819444e-51, /* 0x3569F31D, 0x00000000 */
+		1.57079625129699707031e+00, /* 0x3FF921FB, 0x40000000 */
+		7.54978941586159635335e-08, /* 0x3E74442D, 0x00000000 */
+		5.39030252995776476554e-15, /* 0x3CF84698, 0x80000000 */
+		3.28200341580791294123e-22, /* 0x3B78CC51, 0x60000000 */
+		1.27065575308067607349e-29, /* 0x39F01B83, 0x80000000 */
+		1.22933308981111328932e-36, /* 0x387A2520, 0x40000000 */
+		2.73370053816464559624e-44, /* 0x36E38222, 0x80000000 */
+		2.16741683877804819444e-51, /* 0x3569F31D, 0x00000000 */
 	};
 
-	static const double			
-	zero   = 0.0,
-	one    = 1.0,
-	two24   =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
-	twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
+	static const double
+		zero = 0.0,
+		one = 1.0,
+		two24 = 1.67772160000000000000e+07,	 /* 0x41700000, 0x00000000 */
+		twon24 = 5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
-	int jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;
-	double z,fw,f[20],fq[20],q[20];
+	int jz, jx, jv, jp, jk, carry, n, iq[20], i, j, k, m, q0, ih;
+	double z, fw, f[20], fq[20], q[20];
 
-    /* initialize jk*/
+	/* initialize jk*/
 	jk = init_jk[prec];
 	jp = jk;
 
-    /* determine jx,jv,q0, note that 3>q0 */
-	jx =  nx-1;
-	jv = (e0-3)/24; if(jv<0) jv=0;
-	q0 =  e0-24*(jv+1);
+	/* determine jx,jv,q0, note that 3>q0 */
+	jx = nx - 1;
+	jv = (e0 - 3) / 24;
+	if (jv < 0)
+		jv = 0;
+	q0 = e0 - 24 * (jv + 1);
 
-    /* set up f[0] to f[jx+jk] where f[jx+jk] = ipio2[jv+jk] */
-	j = jv-jx; m = jx+jk;
-	for(i=0;i<=m;i++,j++) f[i] = (j<0)? zero : (double) ipio2[j];
+	/* set up f[0] to f[jx+jk] where f[jx+jk] = ipio2[jv+jk] */
+	j = jv - jx;
+	m = jx + jk;
+	for (i = 0; i <= m; i++, j++)
+		f[i] = (j < 0) ? zero : (double)ipio2[j];
 
-    /* compute q[0],q[1],...q[jk] */
-	for (i=0;i<=jk;i++) {
-	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+	/* compute q[0],q[1],...q[jk] */
+	for (i = 0; i <= jk; i++)
+	{
+		for (j = 0, fw = 0.0; j <= jx; j++)
+			fw += x[j] * f[jx + i - j];
+		q[i] = fw;
 	}
 
 	jz = jk;
 recompute:
-    /* distill q[] into iq[] reversingly */
-	for(i=0,j=jz,z=q[jz];j>0;i++,j--) {
-	    fw    =  (double)((int)(twon24* z));
-	    iq[i] =  (int)(z-two24*fw);
-	    z     =  q[j-1]+fw;
+	/* distill q[] into iq[] reversingly */
+	for (i = 0, j = jz, z = q[jz]; j > 0; i++, j--)
+	{
+		fw = (double)((int)(twon24 * z));
+		iq[i] = (int)(z - two24 * fw);
+		z = q[j - 1] + fw;
 	}
 
-    /* compute n */
-	z  = fdlibm_scalbn(z,q0);		/* actual value of z */
-	z -= 8.0*fdlibm_floor(z*0.125);		/* trim off integer >= 8 */
-	n  = (int) z;
+	/* compute n */
+	z = fdlibm_scalbn(z, q0);			/* actual value of z */
+	z -= 8.0 * fdlibm_floor(z * 0.125); /* trim off integer >= 8 */
+	n = (int)z;
 	z -= (double)n;
 	ih = 0;
-	if(q0>0) {	/* need iq[jz-1] to determine n */
-	    i  = (iq[jz-1]>>(24-q0)); n += i;
-	    iq[jz-1] -= i<<(24-q0);
-	    ih = iq[jz-1]>>(23-q0);
-	} 
-	else if(q0==0) ih = iq[jz-1]>>23;
-	else if(z>=0.5) ih=2;
-
-	if(ih>0) {	/* q > 0.5 */
-	    n += 1; carry = 0;
-	    for(i=0;i<jz ;i++) {	/* compute 1-q */
-		j = iq[i];
-		if(carry==0) {
-		    if(j!=0) {
-			carry = 1; iq[i] = 0x1000000- j;
-		    }
-		} else  iq[i] = 0xffffff - j;
-	    }
-	    if(q0>0) {		/* rare case: chance is 1 in 12 */
-	        switch(q0) {
-	        case 1:
-	    	   iq[jz-1] &= 0x7fffff; break;
-	    	case 2:
-	    	   iq[jz-1] &= 0x3fffff; break;
-	        }
-	    }
-	    if(ih==2) {
-		z = one - z;
-		if(carry!=0) z -= fdlibm_scalbn(one,q0);
-	    }
+	if (q0 > 0)
+	{ /* need iq[jz-1] to determine n */
+		i = (iq[jz - 1] >> (24 - q0));
+		n += i;
+		iq[jz - 1] -= i << (24 - q0);
+		ih = iq[jz - 1] >> (23 - q0);
 	}
+	else if (q0 == 0)
+		ih = iq[jz - 1] >> 23;
+	else if (z >= 0.5)
+		ih = 2;
 
-    /* check if recomputation is needed */
-	if(z==zero) {
-	    j = 0;
-	    for (i=jz-1;i>=jk;i--) j |= iq[i];
-	    if(j==0) { /* need recomputation */
-		for(k=1;iq[jk-k]==0;k++);   /* k = no. of terms needed */
-
-		for(i=jz+1;i<=jz+k;i++) {   /* add q[jz+1] to q[jz+k] */
-		    f[jx+i] = (double) ipio2[jv+i];
-		    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
-		    q[i] = fw;
+	if (ih > 0)
+	{ /* q > 0.5 */
+		n += 1;
+		carry = 0;
+		for (i = 0; i < jz; i++)
+		{ /* compute 1-q */
+			j = iq[i];
+			if (carry == 0)
+			{
+				if (j != 0)
+				{
+					carry = 1;
+					iq[i] = 0x1000000 - j;
+				}
+			}
+			else
+				iq[i] = 0xffffff - j;
 		}
-		jz += k;
-		goto recompute;
-	    }
+		if (q0 > 0)
+		{ /* rare case: chance is 1 in 12 */
+			switch (q0)
+			{
+			case 1:
+				iq[jz - 1] &= 0x7fffff;
+				break;
+			case 2:
+				iq[jz - 1] &= 0x3fffff;
+				break;
+			}
+		}
+		if (ih == 2)
+		{
+			z = one - z;
+			if (carry != 0)
+				z -= fdlibm_scalbn(one, q0);
+		}
 	}
 
-    /* chop off zero terms */
-	if(z==0.0) {
-	    jz -= 1; q0 -= 24;
-	    while(iq[jz]==0) { jz--; q0-=24;}
-	} else { /* break z into 24-bit if necessary */
-	    z = fdlibm_scalbn(z,-q0);
-	    if(z>=two24) { 
-		fw = (double)((int)(twon24*z));
-		iq[jz] = (int)(z-two24*fw);
-		jz += 1; q0 += 24;
-		iq[jz] = (int) fw;
-	    } else iq[jz] = (int) z ;
+	/* check if recomputation is needed */
+	if (z == zero)
+	{
+		j = 0;
+		for (i = jz - 1; i >= jk; i--)
+			j |= iq[i];
+		if (j == 0)
+		{ /* need recomputation */
+			for (k = 1; iq[jk - k] == 0; k++)
+				; /* k = no. of terms needed */
+
+			for (i = jz + 1; i <= jz + k; i++)
+			{ /* add q[jz+1] to q[jz+k] */
+				f[jx + i] = (double)ipio2[jv + i];
+				for (j = 0, fw = 0.0; j <= jx; j++)
+					fw += x[j] * f[jx + i - j];
+				q[i] = fw;
+			}
+			jz += k;
+			goto recompute;
+		}
 	}
 
-    /* convert integer "bit" chunk to floating-point value */
-	fw = fdlibm_scalbn(one,q0);
-	for(i=jz;i>=0;i--) {
-	    q[i] = fw*(double)iq[i]; fw*=twon24;
+	/* chop off zero terms */
+	if (z == 0.0)
+	{
+		jz -= 1;
+		q0 -= 24;
+		while (iq[jz] == 0)
+		{
+			jz--;
+			q0 -= 24;
+		}
+	}
+	else
+	{ /* break z into 24-bit if necessary */
+		z = fdlibm_scalbn(z, -q0);
+		if (z >= two24)
+		{
+			fw = (double)((int)(twon24 * z));
+			iq[jz] = (int)(z - two24 * fw);
+			jz += 1;
+			q0 += 24;
+			iq[jz] = (int)fw;
+		}
+		else
+			iq[jz] = (int)z;
 	}
 
-    /* compute PIo2[0,...,jp]*q[jz,...,0] */
-	for(i=jz;i>=0;i--) {
-	    for(fw=0.0,k=0;k<=jp&&k<=jz-i;k++) fw += PIo2[k]*q[i+k];
-	    fq[jz-i] = fw;
+	/* convert integer "bit" chunk to floating-point value */
+	fw = fdlibm_scalbn(one, q0);
+	for (i = jz; i >= 0; i--)
+	{
+		q[i] = fw * (double)iq[i];
+		fw *= twon24;
 	}
 
-    /* compress fq[] into y[] */
-	switch(prec) {
-	    case 0:
+	/* compute PIo2[0,...,jp]*q[jz,...,0] */
+	for (i = jz; i >= 0; i--)
+	{
+		for (fw = 0.0, k = 0; k <= jp && k <= jz - i; k++)
+			fw += PIo2[k] * q[i + k];
+		fq[jz - i] = fw;
+	}
+
+	/* compress fq[] into y[] */
+	switch (prec)
+	{
+	case 0:
 		fw = 0.0;
-		for (i=jz;i>=0;i--) fw += fq[i];
-		y[0] = (ih==0)? fw: -fw; 
+		for (i = jz; i >= 0; i--)
+			fw += fq[i];
+		y[0] = (ih == 0) ? fw : -fw;
 		break;
-	    case 1:
-	    case 2:
+	case 1:
+	case 2:
 		fw = 0.0;
-		for (i=jz;i>=0;i--) fw += fq[i]; 
-		y[0] = (ih==0)? fw: -fw; 
-		fw = fq[0]-fw;
-		for (i=1;i<=jz;i++) fw += fq[i];
-		y[1] = (ih==0)? fw: -fw; 
+		for (i = jz; i >= 0; i--)
+			fw += fq[i];
+		y[0] = (ih == 0) ? fw : -fw;
+		fw = fq[0] - fw;
+		for (i = 1; i <= jz; i++)
+			fw += fq[i];
+		y[1] = (ih == 0) ? fw : -fw;
 		break;
-	    case 3:	/* painful */
-		for (i=jz;i>0;i--) {
-		    fw      = fq[i-1]+fq[i]; 
-		    fq[i]  += fq[i-1]-fw;
-		    fq[i-1] = fw;
+	case 3: /* painful */
+		for (i = jz; i > 0; i--)
+		{
+			fw = fq[i - 1] + fq[i];
+			fq[i] += fq[i - 1] - fw;
+			fq[i - 1] = fw;
 		}
-		for (i=jz;i>1;i--) {
-		    fw      = fq[i-1]+fq[i]; 
-		    fq[i]  += fq[i-1]-fw;
-		    fq[i-1] = fw;
+		for (i = jz; i > 1; i--)
+		{
+			fw = fq[i - 1] + fq[i];
+			fq[i] += fq[i - 1] - fw;
+			fq[i - 1] = fw;
 		}
-		for (fw=0.0,i=jz;i>=2;i--) fw += fq[i]; 
-		if(ih==0) {
-		    y[0] =  fq[0]; y[1] =  fq[1]; y[2] =  fw;
-		} else {
-		    y[0] = -fq[0]; y[1] = -fq[1]; y[2] = -fw;
+		for (fw = 0.0, i = jz; i >= 2; i--)
+			fw += fq[i];
+		if (ih == 0)
+		{
+			y[0] = fq[0];
+			y[1] = fq[1];
+			y[2] = fw;
+		}
+		else
+		{
+			y[0] = -fq[0];
+			y[1] = -fq[1];
+			y[2] = -fw;
 		}
 	}
-	return n&7;
+	return n & 7;
 }
-
 
 /*
  * invpio2:  53 bits of 2/pi
@@ -977,202 +1326,253 @@ recompute:
 
 int __ieee754_rem_pio2(double x, double *y)
 {
-	static const double 
-	zero =  0.00000000000000000000e+00, /* 0x00000000, 0x00000000 */
-	half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
-	two24 =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
-	invpio2 =  6.36619772367581382433e-01, /* 0x3FE45F30, 0x6DC9C883 */
-	pio2_1  =  1.57079632673412561417e+00, /* 0x3FF921FB, 0x54400000 */
-	pio2_1t =  6.07710050650619224932e-11, /* 0x3DD0B461, 0x1A626331 */
-	pio2_2  =  6.07710050630396597660e-11, /* 0x3DD0B461, 0x1A600000 */
-	pio2_2t =  2.02226624879595063154e-21, /* 0x3BA3198A, 0x2E037073 */
-	pio2_3  =  2.02226624871116645580e-21, /* 0x3BA3198A, 0x2E000000 */
-	pio2_3t =  8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
+	static const double
+		zero = 0.00000000000000000000e+00,	  /* 0x00000000, 0x00000000 */
+		half = 5.00000000000000000000e-01,	  /* 0x3FE00000, 0x00000000 */
+		two24 = 1.67772160000000000000e+07,	  /* 0x41700000, 0x00000000 */
+		invpio2 = 6.36619772367581382433e-01, /* 0x3FE45F30, 0x6DC9C883 */
+		pio2_1 = 1.57079632673412561417e+00,  /* 0x3FF921FB, 0x54400000 */
+		pio2_1t = 6.07710050650619224932e-11, /* 0x3DD0B461, 0x1A626331 */
+		pio2_2 = 6.07710050630396597660e-11,  /* 0x3DD0B461, 0x1A600000 */
+		pio2_2t = 2.02226624879595063154e-21, /* 0x3BA3198A, 0x2E037073 */
+		pio2_3 = 2.02226624871116645580e-21,  /* 0x3BA3198A, 0x2E000000 */
+		pio2_3t = 8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
 
-	double z,w,t,r,fn;
+	double z, w, t, r, fn;
 	double tx[3];
-	int e0,i,j,nx,n,ix,hx;
+	int e0, i, j, nx, n, ix, hx;
 
-	hx = __HI(x);		/* high word of x */
-	ix = hx&0x7fffffff;
-	if(ix<=0x3fe921fb)   /* |x| ~<= pi/4 , no need for reduction */
-	    {y[0] = x; y[1] = 0; return 0;}
-	if(ix<0x4002d97c) {  /* |x| < 3pi/4, special case with n=+-1 */
-	    if(hx>0) { 
-		z = x - pio2_1;
-		if(ix!=0x3ff921fb) { 	/* 33+53 bit pi is good enough */
-		    y[0] = z - pio2_1t;
-		    y[1] = (z-y[0])-pio2_1t;
-		} else {		/* near pi/2, use 33+33+53 bit pi */
-		    z -= pio2_2;
-		    y[0] = z - pio2_2t;
-		    y[1] = (z-y[0])-pio2_2t;
-		}
-		return 1;
-	    } else {	/* negative x */
-		z = x + pio2_1;
-		if(ix!=0x3ff921fb) { 	/* 33+53 bit pi is good enough */
-		    y[0] = z + pio2_1t;
-		    y[1] = (z-y[0])+pio2_1t;
-		} else {		/* near pi/2, use 33+33+53 bit pi */
-		    z += pio2_2;
-		    y[0] = z + pio2_2t;
-		    y[1] = (z-y[0])+pio2_2t;
-		}
-		return -1;
-	    }
+	hx = __HI(x); /* high word of x */
+	ix = hx & 0x7fffffff;
+	if (ix <= 0x3fe921fb) /* |x| ~<= pi/4 , no need for reduction */
+	{
+		y[0] = x;
+		y[1] = 0;
+		return 0;
 	}
-	if(ix<=0x413921fb) { /* |x| ~<= 2^19*(pi/2), medium size */
-	    t  = fdlibm_fabs(x);
-	    n  = (int) (t*invpio2+half);
-	    fn = (double)n;
-	    r  = t-fn*pio2_1;
-	    w  = fn*pio2_1t;	/* 1st round good to 85 bit */
-	    if(n<32&&ix!=npio2_hw[n-1]) {	
-		y[0] = r-w;	/* quick check no cancellation */
-	    } else {
-	        j  = ix>>20;
-	        y[0] = r-w; 
-	        i = j-(((__HI(y[0]))>>20)&0x7ff);
-	        if(i>16) {  /* 2nd iteration needed, good to 118 */
-		    t  = r;
-		    w  = fn*pio2_2;	
-		    r  = t-w;
-		    w  = fn*pio2_2t-((t-r)-w);	
-		    y[0] = r-w;
-		    i = j-(((__HI(y[0]))>>20)&0x7ff);
-		    if(i>49)  {	/* 3rd iteration need, 151 bits acc */
-		    	t  = r;	/* will cover all possible cases */
-		    	w  = fn*pio2_3;	
-		    	r  = t-w;
-		    	w  = fn*pio2_3t-((t-r)-w);	
-		    	y[0] = r-w;
-		    }
+	if (ix < 0x4002d97c)
+	{ /* |x| < 3pi/4, special case with n=+-1 */
+		if (hx > 0)
+		{
+			z = x - pio2_1;
+			if (ix != 0x3ff921fb)
+			{ /* 33+53 bit pi is good enough */
+				y[0] = z - pio2_1t;
+				y[1] = (z - y[0]) - pio2_1t;
+			}
+			else
+			{ /* near pi/2, use 33+33+53 bit pi */
+				z -= pio2_2;
+				y[0] = z - pio2_2t;
+				y[1] = (z - y[0]) - pio2_2t;
+			}
+			return 1;
 		}
-	    }
-	    y[1] = (r-y[0])-w;
-	    if(hx<0) 	{y[0] = -y[0]; y[1] = -y[1]; return -n;}
-	    else	 return n;
+		else
+		{ /* negative x */
+			z = x + pio2_1;
+			if (ix != 0x3ff921fb)
+			{ /* 33+53 bit pi is good enough */
+				y[0] = z + pio2_1t;
+				y[1] = (z - y[0]) + pio2_1t;
+			}
+			else
+			{ /* near pi/2, use 33+33+53 bit pi */
+				z += pio2_2;
+				y[0] = z + pio2_2t;
+				y[1] = (z - y[0]) + pio2_2t;
+			}
+			return -1;
+		}
 	}
-    /* 
-     * all other (large) arguments
-     */
-	if(ix>=0x7ff00000) {		/* x is inf or NaN */
-	    y[0]=y[1]=x-x; return 0;
+	if (ix <= 0x413921fb)
+	{ /* |x| ~<= 2^19*(pi/2), medium size */
+		t = fdlibm_fabs(x);
+		n = (int)(t * invpio2 + half);
+		fn = (double)n;
+		r = t - fn * pio2_1;
+		w = fn * pio2_1t; /* 1st round good to 85 bit */
+		if (n < 32 && ix != npio2_hw[n - 1])
+		{
+			y[0] = r - w; /* quick check no cancellation */
+		}
+		else
+		{
+			j = ix >> 20;
+			y[0] = r - w;
+			i = j - (((__HI(y[0])) >> 20) & 0x7ff);
+			if (i > 16)
+			{ /* 2nd iteration needed, good to 118 */
+				t = r;
+				w = fn * pio2_2;
+				r = t - w;
+				w = fn * pio2_2t - ((t - r) - w);
+				y[0] = r - w;
+				i = j - (((__HI(y[0])) >> 20) & 0x7ff);
+				if (i > 49)
+				{		   /* 3rd iteration need, 151 bits acc */
+					t = r; /* will cover all possible cases */
+					w = fn * pio2_3;
+					r = t - w;
+					w = fn * pio2_3t - ((t - r) - w);
+					y[0] = r - w;
+				}
+			}
+		}
+		y[1] = (r - y[0]) - w;
+		if (hx < 0)
+		{
+			y[0] = -y[0];
+			y[1] = -y[1];
+			return -n;
+		}
+		else
+			return n;
 	}
-    /* set z = scalbn(|x|,ilogb(x)-23) */
+	/*
+	 * all other (large) arguments
+	 */
+	if (ix >= 0x7ff00000)
+	{ /* x is inf or NaN */
+		y[0] = y[1] = x - x;
+		return 0;
+	}
+	/* set z = scalbn(|x|,ilogb(x)-23) */
 	__LO(z) = __LO(x);
-	e0 	= (ix>>20)-1046;	/* e0 = ilogb(z)-23; */
-	__HI(z) = ix - (e0<<20);
-	for(i=0;i<2;i++) {
+	e0 = (ix >> 20) - 1046; /* e0 = ilogb(z)-23; */
+	__HI(z) = ix - (e0 << 20);
+	for (i = 0; i < 2; i++)
+	{
 		tx[i] = (double)((int)(z));
-		z     = (z-tx[i])*two24;
+		z = (z - tx[i]) * two24;
 	}
 	tx[2] = z;
 	nx = 3;
-	while(tx[nx-1]==zero) nx--;	/* skip zero term */
-	n  =  __kernel_rem_pio2(tx,y,e0,nx,2,two_over_pi);
-	if(hx<0) {y[0] = -y[0]; y[1] = -y[1]; return -n;}
+	while (tx[nx - 1] == zero)
+		nx--; /* skip zero term */
+	n = __kernel_rem_pio2(tx, y, e0, nx, 2, two_over_pi);
+	if (hx < 0)
+	{
+		y[0] = -y[0];
+		y[1] = -y[1];
+		return -n;
+	}
 	return n;
 }
 
 double __kernel_sin(double x, double y, int iy)
 {
 
-	static const double 
-	half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
-	S1  = -1.66666666666666324348e-01, /* 0xBFC55555, 0x55555549 */
-	S2  =  8.33333333332248946124e-03, /* 0x3F811111, 0x1110F8A6 */
-	S3  = -1.98412698298579493134e-04, /* 0xBF2A01A0, 0x19C161D5 */
-	S4  =  2.75573137070700676789e-06, /* 0x3EC71DE3, 0x57B1FE7D */
-	S5  = -2.50507602534068634195e-08, /* 0xBE5AE5E6, 0x8A2B9CEB */
-	S6  =  1.58969099521155010221e-10; /* 0x3DE5D93A, 0x5ACFD57C */
+	static const double
+		half = 5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
+		S1 = -1.66666666666666324348e-01,  /* 0xBFC55555, 0x55555549 */
+		S2 = 8.33333333332248946124e-03,   /* 0x3F811111, 0x1110F8A6 */
+		S3 = -1.98412698298579493134e-04,  /* 0xBF2A01A0, 0x19C161D5 */
+		S4 = 2.75573137070700676789e-06,   /* 0x3EC71DE3, 0x57B1FE7D */
+		S5 = -2.50507602534068634195e-08,  /* 0xBE5AE5E6, 0x8A2B9CEB */
+		S6 = 1.58969099521155010221e-10;   /* 0x3DE5D93A, 0x5ACFD57C */
 
-	double z,r,v;
+	double z, r, v;
 	int ix;
-	ix = __HI(x)&0x7fffffff;	/* high word of x */
-	if(ix<0x3e400000)			/* |x| < 2**-27 */
-	   {if((int)x==0) return x;}		/* generate inexact */
-	z	=  x*x;
-	v	=  z*x;
-	r	=  S2+z*(S3+z*(S4+z*(S5+z*S6)));
-	if(iy==0) return x+v*(S1+z*r);
-	else      return x-((z*(half*y-v*r)-y)-v*S1);
+	ix = __HI(x) & 0x7fffffff; /* high word of x */
+	if (ix < 0x3e400000)	   /* |x| < 2**-27 */
+	{
+		if ((int)x == 0)
+			return x;
+	} /* generate inexact */
+	z = x * x;
+	v = z * x;
+	r = S2 + z * (S3 + z * (S4 + z * (S5 + z * S6)));
+	if (iy == 0)
+		return x + v * (S1 + z * r);
+	else
+		return x - ((z * (half * y - v * r) - y) - v * S1);
 }
 
 double __kernel_cos(double x, double y)
 {
-	static const double 
-	one =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
-	C1  =  4.16666666666666019037e-02, /* 0x3FA55555, 0x5555554C */
-	C2  = -1.38888888888741095749e-03, /* 0xBF56C16C, 0x16C15177 */
-	C3  =  2.48015872894767294178e-05, /* 0x3EFA01A0, 0x19CB1590 */
-	C4  = -2.75573143513906633035e-07, /* 0xBE927E4F, 0x809C52AD */
-	C5  =  2.08757232129817482790e-09, /* 0x3E21EE9E, 0xBDB4B1C4 */
-	C6  = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
+	static const double
+		one = 1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+		C1 = 4.16666666666666019037e-02,  /* 0x3FA55555, 0x5555554C */
+		C2 = -1.38888888888741095749e-03, /* 0xBF56C16C, 0x16C15177 */
+		C3 = 2.48015872894767294178e-05,  /* 0x3EFA01A0, 0x19CB1590 */
+		C4 = -2.75573143513906633035e-07, /* 0xBE927E4F, 0x809C52AD */
+		C5 = 2.08757232129817482790e-09,  /* 0x3E21EE9E, 0xBDB4B1C4 */
+		C6 = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
 
-	double a,hz,z,r,qx;
+	double a, hz, z, r, qx;
 	int ix;
-	ix = __HI(x)&0x7fffffff;	/* ix = |x|'s high word*/
-	if(ix<0x3e400000) {			/* if x < 2**27 */
-	    if(((int)x)==0) return one;		/* generate inexact */
+	ix = __HI(x) & 0x7fffffff; /* ix = |x|'s high word*/
+	if (ix < 0x3e400000)
+	{ /* if x < 2**27 */
+		if (((int)x) == 0)
+			return one; /* generate inexact */
 	}
-	z  = x*x;
-	r  = z*(C1+z*(C2+z*(C3+z*(C4+z*(C5+z*C6)))));
-	if(ix < 0x3FD33333) 			/* if |x| < 0.3 */ 
-	    return one - (0.5*z - (z*r - x*y));
-	else {
-	    if(ix > 0x3fe90000) {		/* x > 0.78125 */
-		qx = 0.28125;
-	    } else {
-	        __HI(qx) = ix-0x00200000;	/* x/4 */
-	        __LO(qx) = 0;
-	    }
-	    hz = 0.5*z-qx;
-	    a  = one-qx;
-	    return a - (hz - (z*r-x*y));
+	z = x * x;
+	r = z * (C1 + z * (C2 + z * (C3 + z * (C4 + z * (C5 + z * C6)))));
+	if (ix < 0x3FD33333) /* if |x| < 0.3 */
+		return one - (0.5 * z - (z * r - x * y));
+	else
+	{
+		if (ix > 0x3fe90000)
+		{ /* x > 0.78125 */
+			qx = 0.28125;
+		}
+		else
+		{
+			__HI(qx) = ix - 0x00200000; /* x/4 */
+			__LO(qx) = 0;
+		}
+		hz = 0.5 * z - qx;
+		a = one - qx;
+		return a - (hz - (z * r - x * y));
 	}
 }
 
 double
-__kernel_tan(double x, double y, int iy) {
+__kernel_tan(double x, double y, int iy)
+{
 	double z, r, v, w, s;
 	int ix, hx;
 
 	static const double xxx[] = {
-			 3.33333333333334091986e-01,	/* 3FD55555, 55555563 */
-			 1.33333333333201242699e-01,	/* 3FC11111, 1110FE7A */
-			 5.39682539762260521377e-02,	/* 3FABA1BA, 1BB341FE */
-			 2.18694882948595424599e-02,	/* 3F9664F4, 8406D637 */
-			 8.86323982359930005737e-03,	/* 3F8226E3, E96E8493 */
-			 3.59207910759131235356e-03,	/* 3F6D6D22, C9560328 */
-			 1.45620945432529025516e-03,	/* 3F57DBC8, FEE08315 */
-			 5.88041240820264096874e-04,	/* 3F4344D8, F2F26501 */
-			 2.46463134818469906812e-04,	/* 3F3026F7, 1A8D1068 */
-			 7.81794442939557092300e-05,	/* 3F147E88, A03792A6 */
-			 7.14072491382608190305e-05,	/* 3F12B80F, 32F0A7E9 */
-			-1.85586374855275456654e-05,	/* BEF375CB, DB605373 */
-			 2.59073051863633712884e-05,	/* 3EFB2A70, 74BF7AD4 */
-	/* one */	 1.00000000000000000000e+00,	/* 3FF00000, 00000000 */
-	/* pio4 */	 7.85398163397448278999e-01,	/* 3FE921FB, 54442D18 */
-	/* pio4lo */	 3.06161699786838301793e-17	/* 3C81A626, 33145C07 */
+		3.33333333333334091986e-01,				/* 3FD55555, 55555563 */
+		1.33333333333201242699e-01,				/* 3FC11111, 1110FE7A */
+		5.39682539762260521377e-02,				/* 3FABA1BA, 1BB341FE */
+		2.18694882948595424599e-02,				/* 3F9664F4, 8406D637 */
+		8.86323982359930005737e-03,				/* 3F8226E3, E96E8493 */
+		3.59207910759131235356e-03,				/* 3F6D6D22, C9560328 */
+		1.45620945432529025516e-03,				/* 3F57DBC8, FEE08315 */
+		5.88041240820264096874e-04,				/* 3F4344D8, F2F26501 */
+		2.46463134818469906812e-04,				/* 3F3026F7, 1A8D1068 */
+		7.81794442939557092300e-05,				/* 3F147E88, A03792A6 */
+		7.14072491382608190305e-05,				/* 3F12B80F, 32F0A7E9 */
+		-1.85586374855275456654e-05,			/* BEF375CB, DB605373 */
+		2.59073051863633712884e-05,				/* 3EFB2A70, 74BF7AD4 */
+		/* one */ 1.00000000000000000000e+00,	/* 3FF00000, 00000000 */
+		/* pio4 */ 7.85398163397448278999e-01,	/* 3FE921FB, 54442D18 */
+		/* pio4lo */ 3.06161699786838301793e-17 /* 3C81A626, 33145C07 */
 	};
-	#define	one	xxx[13]
-	#define	pio4	xxx[14]
-	#define	pio4lo	xxx[15]
-	#define	T	xxx
+#define one xxx[13]
+#define pio4 xxx[14]
+#define pio4lo xxx[15]
+#define T xxx
 	/* INDENT ON */
 
-	hx = __HI(x);		/* high word of x */
-	ix = hx & 0x7fffffff;			/* high word of |x| */
-	if (ix < 0x3e300000) {			/* x < 2**-28 */
-		if ((int) x == 0) {		/* generate inexact */
+	hx = __HI(x);		  /* high word of x */
+	ix = hx & 0x7fffffff; /* high word of |x| */
+	if (ix < 0x3e300000)
+	{ /* x < 2**-28 */
+		if ((int)x == 0)
+		{ /* generate inexact */
 			if (((ix | __LO(x)) | (iy + 1)) == 0)
 				return one / fdlibm_fabs(x);
-			else {
+			else
+			{
 				if (iy == 1)
 					return x;
-				else {	/* compute -1 / (x+y) carefully */
+				else
+				{ /* compute -1 / (x+y) carefully */
 					double a, t;
 
 					z = w = x + y;
@@ -1186,8 +1586,10 @@ __kernel_tan(double x, double y, int iy) {
 			}
 		}
 	}
-	if (ix >= 0x3FE59428) {	/* |x| >= 0.6744 */
-		if (hx < 0) {
+	if (ix >= 0x3FE59428)
+	{ /* |x| >= 0.6744 */
+		if (hx < 0)
+		{
 			x = -x;
 			y = -y;
 		}
@@ -1204,21 +1606,23 @@ __kernel_tan(double x, double y, int iy) {
 	 * x^5(x^2*(T[2]+x^4*T[4]+...+x^22*[T12]))
 	 */
 	r = T[1] + w * (T[3] + w * (T[5] + w * (T[7] + w * (T[9] +
-		w * T[11]))));
+														w * T[11]))));
 	v = z * (T[2] + w * (T[4] + w * (T[6] + w * (T[8] + w * (T[10] +
-		w * T[12])))));
+															 w * T[12])))));
 	s = z * x;
 	r = y + z * (s * (r + v) + y);
 	r += T[0] * s;
 	w = x + r;
-	if (ix >= 0x3FE59428) {
-		v = (double) iy;
-		return (double) (1 - ((hx >> 30) & 2)) *
-			(v - 2.0 * (x - (w * w / (w + v) - r)));
+	if (ix >= 0x3FE59428)
+	{
+		v = (double)iy;
+		return (double)(1 - ((hx >> 30) & 2)) *
+			   (v - 2.0 * (x - (w * w / (w + v) - r)));
 	}
 	if (iy == 1)
 		return w;
-	else {
+	else
+	{
 		/*
 		 * if allow error up to 2 ulp, simply return
 		 * -1.0 / (x+r) here
@@ -1227,116 +1631,133 @@ __kernel_tan(double x, double y, int iy) {
 		double a, t;
 		z = w;
 		__LO(z) = 0;
-		v = r - (z - x);	/* z+v = r+x */
-		t = a = -1.0 / w;	/* a = -1.0/w */
+		v = r - (z - x);  /* z+v = r+x */
+		t = a = -1.0 / w; /* a = -1.0/w */
 		__LO(t) = 0;
 		s = 1.0 + t * z;
 		return t + a * (s + t * v);
 	}
 
-	#undef one
-	#undef pio4
-	#undef pio4lo
-	#undef T
+#undef one
+#undef pio4
+#undef pio4lo
+#undef T
 }
 
 double fdlibm_sin(double x)
 {
-	double y[2],z=0.0;
+	double y[2], z = 0.0;
 	int n, ix;
 
-    /* High word of x. */
+	/* High word of x. */
 	ix = __HI(x);
 
-    /* |x| ~< pi/4 */
+	/* |x| ~< pi/4 */
 	ix &= 0x7fffffff;
-	if(ix <= 0x3fe921fb) return __kernel_sin(x,z,0);
+	if (ix <= 0x3fe921fb)
+		return __kernel_sin(x, z, 0);
 
-    /* sin(Inf or NaN) is NaN */
-	else if (ix>=0x7ff00000) return x-x;
+	/* sin(Inf or NaN) is NaN */
+	else if (ix >= 0x7ff00000)
+		return x - x;
 
-    /* argument reduction needed */
-	else {
-	    n = __ieee754_rem_pio2(x,y);
-	    switch(n&3) {
-		case 0: return  __kernel_sin(y[0],y[1],1);
-		case 1: return  __kernel_cos(y[0],y[1]);
-		case 2: return -__kernel_sin(y[0],y[1],1);
+	/* argument reduction needed */
+	else
+	{
+		n = __ieee754_rem_pio2(x, y);
+		switch (n & 3)
+		{
+		case 0:
+			return __kernel_sin(y[0], y[1], 1);
+		case 1:
+			return __kernel_cos(y[0], y[1]);
+		case 2:
+			return -__kernel_sin(y[0], y[1], 1);
 		default:
-			return -__kernel_cos(y[0],y[1]);
-	    }
+			return -__kernel_cos(y[0], y[1]);
+		}
 	}
 }
 
 double fdlibm_cos(double x)
 {
-	double y[2],z=0.0;
+	double y[2], z = 0.0;
 	int n, ix;
 
-    /* High word of x. */
+	/* High word of x. */
 	ix = __HI(x);
 
-    /* |x| ~< pi/4 */
+	/* |x| ~< pi/4 */
 	ix &= 0x7fffffff;
-	if(ix <= 0x3fe921fb) return __kernel_cos(x,z);
+	if (ix <= 0x3fe921fb)
+		return __kernel_cos(x, z);
 
-    /* cos(Inf or NaN) is NaN */
-	else if (ix>=0x7ff00000) return x-x;
+	/* cos(Inf or NaN) is NaN */
+	else if (ix >= 0x7ff00000)
+		return x - x;
 
-    /* argument reduction needed */
-	else {
-	    n = __ieee754_rem_pio2(x,y);
-	    switch(n&3) {
-		case 0: return  __kernel_cos(y[0],y[1]);
-		case 1: return -__kernel_sin(y[0],y[1],1);
-		case 2: return -__kernel_cos(y[0],y[1]);
+	/* argument reduction needed */
+	else
+	{
+		n = __ieee754_rem_pio2(x, y);
+		switch (n & 3)
+		{
+		case 0:
+			return __kernel_cos(y[0], y[1]);
+		case 1:
+			return -__kernel_sin(y[0], y[1], 1);
+		case 2:
+			return -__kernel_cos(y[0], y[1]);
 		default:
-		        return  __kernel_sin(y[0],y[1],1);
-	    }
+			return __kernel_sin(y[0], y[1], 1);
+		}
 	}
 }
 
 double fdlibm_tan(double x)
 {
-	double y[2],z=0.0;
+	double y[2], z = 0.0;
 	int n, ix;
 
-    /* High word of x. */
+	/* High word of x. */
 	ix = __HI(x);
 
-    /* |x| ~< pi/4 */
+	/* |x| ~< pi/4 */
 	ix &= 0x7fffffff;
-	if(ix <= 0x3fe921fb) return __kernel_tan(x,z,1);
+	if (ix <= 0x3fe921fb)
+		return __kernel_tan(x, z, 1);
 
-    /* tan(Inf or NaN) is NaN */
-	else if (ix>=0x7ff00000) return x-x;		/* NaN */
+	/* tan(Inf or NaN) is NaN */
+	else if (ix >= 0x7ff00000)
+		return x - x; /* NaN */
 
-    /* argument reduction needed */
-	else {
-	    n = __ieee754_rem_pio2(x,y);
-	    return __kernel_tan(y[0],y[1],1-((n&1)<<1)); /*   1 -- n even
-							-1 -- n odd */
+	/* argument reduction needed */
+	else
+	{
+		n = __ieee754_rem_pio2(x, y);
+		return __kernel_tan(y[0], y[1], 1 - ((n & 1) << 1)); /*   1 -- n even
+									-1 -- n odd */
 	}
 }
 
-double fdlibm_asin(double x)		/* wrapper asin */
+double fdlibm_asin(double x) /* wrapper asin */
 {
 	return __ieee754_asin(x);
 }
 
-double fdlibm_acos(double x)		/* wrapper acos */
+double fdlibm_acos(double x) /* wrapper acos */
 {
 	return __ieee754_acos(x);
 }
 
-double fdlibm_atan2(double y, double x)	/* wrapper atan2 */
+double fdlibm_atan2(double y, double x) /* wrapper atan2 */
 {
-	return __ieee754_atan2(y,x);
+	return __ieee754_atan2(y, x);
 }
 
-double fdlibm_pow(double x, double y)	/* wrapper pow */
+double fdlibm_pow(double x, double y) /* wrapper pow */
 {
-	return  __ieee754_pow(x,y);
+	return __ieee754_pow(x, y);
 }
 
 double fdlibm_fmin(double a, double b)
@@ -1351,101 +1772,101 @@ double fdlibm_fmax(double a, double b)
 
 double fdlibm_nextafter(double x, double y)
 {
-	int	hx,hy,ix,iy;
-	unsigned lx,ly;
+	int hx, hy, ix, iy;
+	unsigned lx, ly;
 
-	hx = __HI(x);		/* high word of x */
-	lx = __LO(x);		/* low  word of x */
-	hy = __HI(y);		/* high word of y */
-	ly = __LO(y);		/* low  word of y */
-	ix = hx&0x7fffffff;		/* |x| */
-	iy = hy&0x7fffffff;		/* |y| */
+	hx = __HI(x);		  /* high word of x */
+	lx = __LO(x);		  /* low  word of x */
+	hy = __HI(y);		  /* high word of y */
+	ly = __LO(y);		  /* low  word of y */
+	ix = hx & 0x7fffffff; /* |x| */
+	iy = hy & 0x7fffffff; /* |y| */
 
-	if(((ix>=0x7ff00000)&&((ix-0x7ff00000)|lx)!=0) ||   /* x is nan */ 
-	   ((iy>=0x7ff00000)&&((iy-0x7ff00000)|ly)!=0))     /* y is nan */ 
-	   return x+y;				
-	if(x==y) return x;		/* x=y, return x */
-	if((ix|lx)==0) {			/* x == 0 */
-	    __HI(x) = hy&0x80000000;	/* return +-minsubnormal */
-	    __LO(x) = 1;
-	    y = x*x;
-	    if(y==x) return y; else return x;	/* raise underflow flag */
-	} 
-	if(hx>=0) {				/* x > 0 */
-	    if(hx>hy||((hx==hy)&&(lx>ly))) {	/* x > y, x -= ulp */
-		if(lx==0) hx -= 1;
-		lx -= 1;
-	    } else {				/* x < y, x += ulp */
-		lx += 1;
-		if(lx==0) hx += 1;
-	    }
-	} else {				/* x < 0 */
-	    if(hy>=0||hx>hy||((hx==hy)&&(lx>ly))){/* x < y, x -= ulp */
-		if(lx==0) hx -= 1;
-		lx -= 1;
-	    } else {				/* x > y, x += ulp */
-		lx += 1;
-		if(lx==0) hx += 1;
-	    }
+	if (((ix >= 0x7ff00000) && ((ix - 0x7ff00000) | lx) != 0) || /* x is nan */
+		((iy >= 0x7ff00000) && ((iy - 0x7ff00000) | ly) != 0))	 /* y is nan */
+		return x + y;
+	if (x == y)
+		return x; /* x=y, return x */
+	if ((ix | lx) == 0)
+	{							   /* x == 0 */
+		__HI(x) = hy & 0x80000000; /* return +-minsubnormal */
+		__LO(x) = 1;
+		y = x * x;
+		if (y == x)
+			return y;
+		else
+			return x; /* raise underflow flag */
 	}
-	hy = hx&0x7ff00000;
-	if(hy>=0x7ff00000) return x+x;	/* overflow  */
-	if(hy<0x00100000) {		/* underflow */
-	    y = x*x;
-	    if(y!=x) {		/* raise underflow flag */
-		__HI(y) = hx; __LO(y) = lx;
-		return y;
-	    }
+	if (hx >= 0)
+	{ /* x > 0 */
+		if (hx > hy || ((hx == hy) && (lx > ly)))
+		{ /* x > y, x -= ulp */
+			if (lx == 0)
+				hx -= 1;
+			lx -= 1;
+		}
+		else
+		{ /* x < y, x += ulp */
+			lx += 1;
+			if (lx == 0)
+				hx += 1;
+		}
 	}
-	__HI(x) = hx; __LO(x) = lx;
+	else
+	{ /* x < 0 */
+		if (hy >= 0 || hx > hy || ((hx == hy) && (lx > ly)))
+		{ /* x < y, x -= ulp */
+			if (lx == 0)
+				hx -= 1;
+			lx -= 1;
+		}
+		else
+		{ /* x > y, x += ulp */
+			lx += 1;
+			if (lx == 0)
+				hx += 1;
+		}
+	}
+	hy = hx & 0x7ff00000;
+	if (hy >= 0x7ff00000)
+		return x + x; /* overflow  */
+	if (hy < 0x00100000)
+	{ /* underflow */
+		y = x * x;
+		if (y != x)
+		{ /* raise underflow flag */
+			__HI(y) = hx;
+			__LO(y) = lx;
+			return y;
+		}
+	}
+	__HI(x) = hx;
+	__LO(x) = lx;
 	return x;
 }
 
 float fdlibm_nextafterf(float x, float y)
 {
-	int hx, hy, ix, iy;
+	int ix = __FLT(x);
+	int iy = __FLT(y);
+	int ax = ix & 0x7fffffff;
+	int ay = iy & 0x7fffffff;
 
-	hx = __FLT(x);
-	hy = __FLT(y);
-	ix = hx & 0x7fffffff;			/* |x| */
-	iy = hy & 0x7fffffff;			/* |y| */
-
-	if ((ix > 0x7f800000) ||		/* x is nan */
-		(iy > 0x7f800000))			/* y is nan */
+	if (ax > 0x7f800000 || ay > 0x7f800000)
 		return x + y;
-	if (x == y)
-		return y;						/* x=y, return y */
-	if (ix == 0)
-	{									/* x == 0 */
-		__FLT(x) = ((hy & 0x80000000) | 1);	/* return +-minsubnormal */
-		return x;
-	}
-	if (hx >= 0)
-	{									/* x > 0 */
-		if (hx > hy)
-		{								/* x > y, x -= ulp */
-			hx -= 1;
-		} else
-		{								/* x < y, x += ulp */
-			hx += 1;
-		}
-	} else
-	{									/* x < 0 */
-		if (hy >= 0 || hx > hy)
-		{								/* x < y, x -= ulp */
-			hx -= 1;
-		} else
-		{								/* x > y, x += ulp */
-			hx += 1;
-		}
-	}
-	hy = hx & 0x7f800000;
-	if (hy >= 0x7f800000)
+	if (ix == iy)
+		return y;
+	if (ax == 0)
 	{
-		x = x + x;						/* overflow  */
-		return x;						/* overflow  */
+		if (ay == 0)
+			return y;
+		ix = (iy & 0x80000000) | 1;
 	}
-	__FLT(x) = hx;
+	else if (ax > ay || ((ix ^ iy) & 0x80000000))
+		ix--;
+	else
+		ix++;
+	__FLT(x) = ix;
 	return x;
 }
 
@@ -1453,42 +1874,71 @@ double fdlibm_ceil(double x)
 {
 	static const double huge = 1.0e300;
 
-	int i0,i1,j0;
-	unsigned i,j;
-	i0 =  __HI(x);
-	i1 =  __LO(x);
-	j0 = ((i0>>20)&0x7ff)-0x3ff;
-	if(j0<20) {
-	    if(j0<0) { 	/* raise inexact if x != 0 */
-		if(huge+x>0.0) {/* return 0*sign(x) if |x|<1 */
-		    if(i0<0) {i0=0x80000000;i1=0;} 
-		    else if((i0|i1)!=0) { i0=0x3ff00000;i1=0;}
+	int i0, i1, j0;
+	unsigned i, j;
+	i0 = __HI(x);
+	i1 = __LO(x);
+	j0 = ((i0 >> 20) & 0x7ff) - 0x3ff;
+	if (j0 < 20)
+	{
+		if (j0 < 0)
+		{ /* raise inexact if x != 0 */
+			if (huge + x > 0.0)
+			{ /* return 0*sign(x) if |x|<1 */
+				if (i0 < 0)
+				{
+					i0 = 0x80000000;
+					i1 = 0;
+				}
+				else if ((i0 | i1) != 0)
+				{
+					i0 = 0x3ff00000;
+					i1 = 0;
+				}
+			}
 		}
-	    } else {
-		i = (0x000fffff)>>j0;
-		if(((i0&i)|i1)==0) return x; /* x is integral */
-		if(huge+x>0.0) {	/* raise inexact flag */
-		    if(i0>0) i0 += (0x00100000)>>j0;
-		    i0 &= (~i); i1=0;
+		else
+		{
+			i = (0x000fffff) >> j0;
+			if (((i0 & i) | i1) == 0)
+				return x; /* x is integral */
+			if (huge + x > 0.0)
+			{ /* raise inexact flag */
+				if (i0 > 0)
+					i0 += (0x00100000) >> j0;
+				i0 &= (~i);
+				i1 = 0;
+			}
 		}
-	    }
-	} else if (j0>51) {
-	    if(j0==0x400) return x+x;	/* inf or NaN */
-	    else return x;		/* x is integral */
-	} else {
-	    i = ((unsigned)(0xffffffff))>>(j0-20);
-	    if((i1&i)==0) return x;	/* x is integral */
-	    if(huge+x>0.0) { 		/* raise inexact flag */
-		if(i0>0) {
-		    if(j0==20) i0+=1; 
-		    else {
-			j = i1 + (1<<(52-j0));
-			if(j<i1) i0+=1;	/* got a carry */
-			i1 = j;
-		    }
+	}
+	else if (j0 > 51)
+	{
+		if (j0 == 0x400)
+			return x + x; /* inf or NaN */
+		else
+			return x; /* x is integral */
+	}
+	else
+	{
+		i = ((unsigned)(0xffffffff)) >> (j0 - 20);
+		if ((i1 & i) == 0)
+			return x; /* x is integral */
+		if (huge + x > 0.0)
+		{ /* raise inexact flag */
+			if (i0 > 0)
+			{
+				if (j0 == 20)
+					i0 += 1;
+				else
+				{
+					j = i1 + (1 << (52 - j0));
+					if (j < (unsigned)i1)
+						i0 += 1; /* got a carry */
+					i1 = j;
+				}
+			}
+			i1 &= (~i);
 		}
-		i1 &= (~i);
-	    }
 	}
 	__HI(x) = i0;
 	__LO(x) = i1;
@@ -1497,10 +1947,10 @@ double fdlibm_ceil(double x)
 
 int fdlibm_isnan(double x)
 {
-	int hx,lx;
-	hx = (__HI(x)&0x7fffffff);
+	int hx, lx;
+	hx = (__HI(x) & 0x7fffffff);
 	lx = __LO(x);
-	hx |= (unsigned)(lx|(-lx))>>31;	
+	hx |= (unsigned)(lx | (-lx)) >> 31;
 	hx = 0x7ff00000 - hx;
-	return ((unsigned)(hx))>>31;
+	return ((unsigned)(hx)) >> 31;
 }

--- a/misc/ufbxi.natvis
+++ b/misc/ufbxi.natvis
@@ -115,7 +115,7 @@
     </Expand>
   </Type>
 
-  <Type Name="ufbxi_double_list"><DisplayString>{{ count={count} }}</DisplayString><Expand><ArrayItems><Size>count</Size><ValuePointer>data</ValuePointer></ArrayItems></Expand></Type>
+  <Type Name="ufbxi_bake_time_list"><DisplayString>{{ count={count} }}</DisplayString><Expand><ArrayItems><Size>count</Size><ValuePointer>data</ValuePointer></ArrayItems></Expand></Type>
 
   <Type Name="ufbxos_wait_sema">
 	  <Expand>

--- a/test/runner.c
+++ b/test/runner.c
@@ -3230,6 +3230,11 @@ void ufbxt_do_deflate_test(const char *name, void (*test_fn)(const ufbxt_inflate
 	ufbx_load_opts user_opts = { 0 }; \
 	ufbxt_do_file_test(#name, &ufbxt_test_fn_imp_file_##name##_##suffix, #suffix, user_opts, flags | UFBXT_FILE_TEST_FLAG_ALTERNATIVE); } \
 	void ufbxt_test_fn_imp_file_##name##_##suffix(ufbx_scene *scene, ufbxt_diff_error *err, ufbx_error *load_error)
+#define UFBXT_FILE_TEST_ALT_SUFFIX_FLAGS(name, file, suffix, flags) void ufbxt_test_fn_imp_file_##name(ufbx_scene *scene, ufbxt_diff_error *err, ufbx_error *load_error); \
+	void ufbxt_test_fn_file_##name(void) { \
+	ufbx_load_opts user_opts = { 0 }; \
+	ufbxt_do_file_test(#file, &ufbxt_test_fn_imp_file_##name, #suffix, user_opts, flags | UFBXT_FILE_TEST_FLAG_ALTERNATIVE); } \
+	void ufbxt_test_fn_imp_file_##name(ufbx_scene *scene, ufbxt_diff_error *err, ufbx_error *load_error)
 #define UFBXT_FILE_TEST_SUFFIX_OPTS_FLAGS(name, suffix, get_opts, flags) void ufbxt_test_fn_imp_file_##name##_##suffix(ufbx_scene *scene, ufbxt_diff_error *err, ufbx_error *load_error); \
 	void ufbxt_test_fn_file_##name##_##suffix(void) { \
 	ufbxt_do_file_test(#name, &ufbxt_test_fn_imp_file_##name##_##suffix, #suffix, get_opts(), flags | UFBXT_FILE_TEST_FLAG_ALTERNATIVE); } \
@@ -3253,6 +3258,7 @@ void ufbxt_do_deflate_test(const char *name, void (*test_fn)(const ufbxt_inflate
 #define UFBXT_FILE_TEST_OPTS(name, get_opts) UFBXT_FILE_TEST_OPTS_FLAGS(name, get_opts, 0)
 #define UFBXT_FILE_TEST_SUFFIX(name, suffix) UFBXT_FILE_TEST_SUFFIX_FLAGS(name, suffix, 0)
 #define UFBXT_FILE_TEST_SUFFIX_OPTS(name, suffix, get_opts) UFBXT_FILE_TEST_SUFFIX_OPTS_FLAGS(name, suffix, get_opts, 0)
+#define UFBXT_FILE_TEST_ALT_SUFFIX(name, file, suffix) UFBXT_FILE_TEST_ALT_SUFFIX_FLAGS(name, file, suffix, 0)
 #define UFBXT_FILE_TEST_ALT(name, file) UFBXT_FILE_TEST_ALT_FLAGS(name, file, 0)
 #define UFBXT_FILE_TEST_OPTS_ALT(name, file, get_opts) UFBXT_FILE_TEST_OPTS_ALT_FLAGS(name, file, get_opts, 0)
 
@@ -3264,6 +3270,7 @@ void ufbxt_do_deflate_test(const char *name, void (*test_fn)(const ufbxt_inflate
 #undef UFBXT_FILE_TEST_PATH_FLAGS
 #undef UFBXT_FILE_TEST_OPTS_FLAGS
 #undef UFBXT_FILE_TEST_SUFFIX_FLAGS
+#undef UFBXT_FILE_TEST_ALT_SUFFIX_FLAGS
 #undef UFBXT_FILE_TEST_SUFFIX_OPTS_FLAGS
 #undef UFBXT_FILE_TEST_ALT_FLAGS
 #undef UFBXT_FILE_TEST_OPTS_ALT_FLAGS
@@ -3274,6 +3281,7 @@ void ufbxt_do_deflate_test(const char *name, void (*test_fn)(const ufbxt_inflate
 #define UFBXT_FILE_TEST_PATH_FLAGS(name, path, flags) { UFBXT_TEST_GROUP, #name, &ufbxt_test_fn_file_##name },
 #define UFBXT_FILE_TEST_OPTS_FLAGS(name, get_opts, flags) { UFBXT_TEST_GROUP, #name, &ufbxt_test_fn_file_##name },
 #define UFBXT_FILE_TEST_SUFFIX_FLAGS(name, suffix, flags) { UFBXT_TEST_GROUP, #name "_" #suffix, &ufbxt_test_fn_file_##name##_##suffix },
+#define UFBXT_FILE_TEST_ALT_SUFFIX_FLAGS(name, file, suffix, flags) { UFBXT_TEST_GROUP, #name, &ufbxt_test_fn_file_##name },
 #define UFBXT_FILE_TEST_SUFFIX_OPTS_FLAGS(name, suffix, get_opts, flags) { UFBXT_TEST_GROUP, #name "_" #suffix, &ufbxt_test_fn_file_##name##_##suffix },
 #define UFBXT_FILE_TEST_ALT_FLAGS(name, file, flags) { UFBXT_TEST_GROUP, #name, &ufbxt_test_fn_file_##name },
 #define UFBXT_FILE_TEST_OPTS_ALT_FLAGS(name, file, get_opts, flags) { UFBXT_TEST_GROUP, #name, &ufbxt_test_fn_file_##name },

--- a/test/runner.c
+++ b/test/runner.c
@@ -19,6 +19,7 @@ static void ufbxt_assert_fail(const char *file, uint32_t line, const char *expr)
 #include <stdio.h>
 #include <stdarg.h>
 #include <math.h>
+#include <float.h>
 
 #if defined(UFBXT_STACK_LIMIT)
 	static int ufbxt_main_argc;

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1887,6 +1887,35 @@ UFBXT_FILE_TEST_ALT(maya_anim_linear_minimum_timestep, maya_anim_linear)
 }
 #endif
 
+UFBXT_FILE_TEST(maya_huge_stepped_tangents)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	// opts.no_minimum_timestep = true;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
+		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f } },
+		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f } },
+		{ nextafter(12.0/24.0, -INFINITY), { 2.0f, 0.0f, 0.0f } },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f } },
+		{ nextafter(12.0/24.0, INFINITY), { 2.0f, 0.0f, 0.0f } },
+		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f } },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
 UFBXT_FILE_TEST(maya_anim_diffuse_curve)
 #if UFBXT_IMPL
 {

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1806,8 +1806,10 @@ static void ufbxt_diff_baked_vec3_imp(ufbxt_diff_error *err, const ufbx_baked_ve
 		ufbx_baked_vec3 key = list.data[i];
 
 		if (key.time != ref.time) ufbxt_logf("key.time=%f, ref.time=%f", key.time, ref.time);
+		if (key.flags != ref.flags) ufbxt_logf("key.flags=0x%x, ref.flags=0x%x", key.flags, ref.flags);
 		ufbxt_assert(key.time == ref.time);
 		ufbxt_assert_close_vec3(err, key.value, ref.value);
+		ufbxt_assert(key.flags == ref.flags);
 	}
 	ufbxt_assert(list.count == num_refs);
 }
@@ -1825,6 +1827,7 @@ static void ufbxt_diff_baked_quat_imp(ufbxt_diff_error *err, const ufbx_baked_ve
 		if (key.time != ref.time) ufbxt_logf("key.time=%f, ref.time=%f", key.time, ref.time);
 		ufbxt_assert(key.time == ref.time);
 		ufbxt_assert_close_vec3(err, key_euler, ref.value);
+		ufbxt_assert(key.flags == ref.flags);
 	}
 	ufbxt_assert(list.count == num_refs);
 }
@@ -1838,7 +1841,7 @@ UFBXT_FILE_TEST(maya_anim_linear)
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -1846,13 +1849,13 @@ UFBXT_FILE_TEST(maya_anim_linear)
 	ufbxt_assert(bake);
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
-		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f } },
-		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f } },
-		{ nextafter(12.0/24.0, -INFINITY), { 2.0f, 0.0f, 0.0f } },
-		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f } },
-		{ nextafter(12.0/24.0, INFINITY), { 2.0f, 0.0f, 0.0f } },
-		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f } },
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(12.0/24.0, -INFINITY), { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(12.0/24.0, INFINITY), { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -1863,7 +1866,7 @@ UFBXT_FILE_TEST(maya_anim_linear)
 }
 #endif
 
-UFBXT_FILE_TEST_ALT(maya_anim_linear_minimum_timestep, maya_anim_linear)
+UFBXT_FILE_TEST_ALT(maya_anim_linear_default, maya_anim_linear)
 #if UFBXT_IMPL
 {
 	ufbx_error error;
@@ -1872,13 +1875,13 @@ UFBXT_FILE_TEST_ALT(maya_anim_linear_minimum_timestep, maya_anim_linear)
 	ufbxt_assert(bake);
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
-		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f } },
-		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f } },
-		{ 12.0/24.0 - 0.001, { 2.0f, 0.0f, 0.0f } },
-		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f } },
-		{ 12.0/24.0 + 0.001, { 2.0f, 0.0f, 0.0f } },
-		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f } },
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 12.0/24.0 - 0.001, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 12.0/24.0 + 0.001, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -1893,7 +1896,7 @@ UFBXT_FILE_TEST(maya_huge_stepped_tangents)
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -1901,27 +1904,27 @@ UFBXT_FILE_TEST(maya_huge_stepped_tangents)
 	ufbxt_assert(bake);
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0, { 0.0f } },
-		{ nextafter(10.0, -INFINITY), { 0.0f } },
-		{ 10.0, { 1.0f } },
-		{ nextafter(10.0, +INFINITY), { 2.0f } },
-		{ 20.0, { 2.0f } },
-		{ nextafter(100.0, -INFINITY), { 2.0f } },
-		{ 100.0, { 3.0f } },
-		{ nextafter(100.0, +INFINITY), { 4.0f } },
-		{ 200.0, { 4.0f } },
-		{ nextafter(1000.0, -INFINITY), { 4.0f } },
-		{ 1000.0, { 5.0f } },
-		{ nextafter(1000.0, +INFINITY), { 6.0f } },
-		{ 2000.0, { 6.0f } },
-		{ nextafter(10000.0, -INFINITY), { 6.0f } },
-		{ 10000.0, { 7.0f } },
-		{ nextafter(10000.0, +INFINITY), { 8.0f } },
-		{ 20000.0, { 8.0f } },
-		{ nextafter(100000.0, -INFINITY), { 8.0f } },
-		{ 100000.0, { 9.0f } },
-		{ nextafter(100000.0, +INFINITY), { 10.0f } },
-		{ 200000.0, { 10.0f } },
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10.0, -INFINITY), { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10.0, +INFINITY), { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(100.0, -INFINITY), { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(100.0, +INFINITY), { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(1000.0, -INFINITY), { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(1000.0, +INFINITY), { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10000.0, -INFINITY), { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10000.0, +INFINITY), { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(100000.0, -INFINITY), { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(100000.0, +INFINITY), { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -1932,7 +1935,50 @@ UFBXT_FILE_TEST(maya_huge_stepped_tangents)
 }
 #endif
 
-UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_minimum_timestep, maya_huge_stepped_tangents)
+UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_identical, maya_huge_stepped_tangents)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_IDENTICAL_TIME;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_default, maya_huge_stepped_tangents)
 #if UFBXT_IMPL
 {
 	ufbx_error error;
@@ -1943,27 +1989,27 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_minimum_timestep, maya_huge_stepp
 	const double step = 0.001;
 	const double epsilon = 1.0 + (double)FLT_EPSILON * 4.0;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0, { 0.0f } },
-		{ 10.0 - step, { 0.0f } },
-		{ 10.0, { 1.0f } },
-		{ 10.0 + step, { 2.0f } },
-		{ 20.0, { 2.0f } },
-		{ 100.0 - step, { 2.0f } },
-		{ 100.0, { 3.0f } },
-		{ 100.0 + step, { 4.0f } },
-		{ 200.0, { 4.0f } },
-		{ 1000.0 - step, { 4.0f } },
-		{ 1000.0, { 5.0f } },
-		{ 1000.0 + step, { 6.0f } },
-		{ 2000.0, { 6.0f } },
-		{ 10000.0 / epsilon, { 6.0f } },
-		{ 10000.0, { 7.0f } },
-		{ 10000.0 * epsilon, { 8.0f } },
-		{ 20000.0, { 8.0f } },
-		{ 100000.0 / epsilon, { 8.0f } },
-		{ 100000.0, { 9.0f } },
-		{ 100000.0 * epsilon, { 10.0f } },
-		{ 200000.0, { 10.0f } },
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 / epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 * epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 / epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 * epsilon, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -1974,13 +2020,13 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_minimum_timestep, maya_huge_stepp
 }
 #endif
 
-UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_custom_timestep, maya_huge_stepped_tangents)
+UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_custom, maya_huge_stepped_tangents)
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
-	opts.timestep_absolute = 0.1;
-	opts.timestep_relative = 0.0005;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION;
+	opts.step_custom_duration = 0.1;
+	opts.step_custom_epsilon = 0.0005;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -1990,27 +2036,27 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_custom_timestep, maya_huge_steppe
 	const double step = 0.1;
 	const double epsilon = 1.0 + 0.0005;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0, { 0.0f } },
-		{ 10.0 - step, { 0.0f } },
-		{ 10.0, { 1.0f } },
-		{ 10.0 + step, { 2.0f } },
-		{ 20.0, { 2.0f } },
-		{ 100.0 - step, { 2.0f } },
-		{ 100.0, { 3.0f } },
-		{ 100.0 + step, { 4.0f } },
-		{ 200.0, { 4.0f } },
-		{ 1000.0 / epsilon, { 4.0f } },
-		{ 1000.0, { 5.0f } },
-		{ 1000.0 * epsilon, { 6.0f } },
-		{ 2000.0, { 6.0f } },
-		{ 10000.0 / epsilon, { 6.0f } },
-		{ 10000.0, { 7.0f } },
-		{ 10000.0 * epsilon, { 8.0f } },
-		{ 20000.0, { 8.0f } },
-		{ 100000.0 / epsilon, { 8.0f } },
-		{ 100000.0, { 9.0f } },
-		{ 100000.0 * epsilon, { 10.0f } },
-		{ 200000.0, { 10.0f } },
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 / epsilon, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 * epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 / epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 * epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 / epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 * epsilon, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2021,12 +2067,12 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_custom_timestep, maya_huge_steppe
 }
 #endif
 
-UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_timestep, maya_huge_stepped_tangents)
+UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_custom, maya_huge_stepped_tangents)
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
-	opts.timestep_absolute = 100.0;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION;
+	opts.step_custom_duration = 100.0;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -2035,64 +2081,23 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_timestep, maya_huge_stepped_
 
 	const double step = 100.0;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0, { 0.0f } },
-		{ 100.0, { 3.0f } },
-		{ 200.0, { 4.0f } },
-		{ 1000.0 - step, { 4.0f } },
-		{ 1000.0, { 5.0f } },
-		{ 1000.0 + step, { 6.0f } },
-		{ 2000.0, { 6.0f } },
-		{ 10000.0 - step, { 6.0f } },
-		{ 10000.0, { 7.0f } },
-		{ 10000.0 + step, { 8.0f } },
-		{ 20000.0, { 8.0f } },
-		{ 100000.0 - step, { 8.0f } },
-		{ 100000.0, { 9.0f } },
-		{ 100000.0 + step, { 10.0f } },
-		{ 200000.0, { 10.0f } },
-	};
-
-	ufbxt_assert(bake->nodes.count == 1);
-	ufbx_baked_node *node = &bake->nodes.data[0];
-	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
-
-	ufbx_free_baked_anim(bake);
-}
-#endif
-
-UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_float_epsilon, maya_huge_stepped_tangents)
-#if UFBXT_IMPL
-{
-	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_FLOAT;
-
-	ufbx_error error;
-	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
-	if (!bake) ufbxt_log_error(&error);
-	ufbxt_assert(bake);
-
-	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0, { 0.0f } },
-		{ nextafterf(10.0, -INFINITY), { 0.0f } },
-		{ 10.0, { 1.0f } },
-		{ nextafterf(10.0, +INFINITY), { 2.0f } },
-		{ 20.0, { 2.0f } },
-		{ nextafterf(100.0, -INFINITY), { 2.0f } },
-		{ 100.0, { 3.0f } },
-		{ nextafterf(100.0, +INFINITY), { 4.0f } },
-		{ 200.0, { 4.0f } },
-		{ nextafterf(1000.0, -INFINITY), { 4.0f } },
-		{ 1000.0, { 5.0f } },
-		{ nextafterf(1000.0, +INFINITY), { 6.0f } },
-		{ 2000.0, { 6.0f } },
-		{ nextafterf(10000.0, -INFINITY), { 6.0f } },
-		{ 10000.0, { 7.0f } },
-		{ nextafterf(10000.0, +INFINITY), { 8.0f } },
-		{ 20000.0, { 8.0f } },
-		{ nextafterf(100000.0, -INFINITY), { 8.0f } },
-		{ 100000.0, { 9.0f } },
-		{ nextafterf(100000.0, +INFINITY), { 10.0f } },
-		{ 200000.0, { 10.0f } },
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 - step, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 + step, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 - step, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 + step, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2107,7 +2112,7 @@ UFBXT_FILE_TEST(maya_stepped_tangent_sign)
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -2115,16 +2120,16 @@ UFBXT_FILE_TEST(maya_stepped_tangent_sign)
 	ufbxt_assert(bake);
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ -2.0, { -3.0f } },
-		{ nextafter(-1.0, -INFINITY), { -3.0f } },
-		{ -1.0, { -2.0f } },
-		{ nextafter(-1.0, +INFINITY), { -1.0f } },
-		{ -0.1, { -1.0f } },
-		{ 0.1, { 1.0f } },
-		{ nextafter(1.0, -INFINITY), { 1.0f } },
-		{ 1.0, { 2.0f } },
-		{ nextafter(1.0, +INFINITY), { 3.0f } },
-		{ 2.0, { 3.0f } },
+		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(-1.0, -INFINITY), { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(-1.0, +INFINITY), { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(1.0, -INFINITY), { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(1.0, +INFINITY), { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2147,16 +2152,16 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_default, maya_stepped_tangent_sign
 
 	double step = 0.001;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ -2.0, { -3.0f } },
-		{ -1.0 - step, { -3.0f } },
-		{ -1.0, { -2.0f } },
-		{ -1.0 + step, { -1.0f } },
-		{ -0.1, { -1.0f } },
-		{ 0.1, { 1.0f } },
-		{ 1.0 - step, { 1.0f } },
-		{ 1.0, { 2.0f } },
-		{ 1.0 + step, { 3.0f } },
-		{ 2.0, { 3.0f } },
+		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 - step, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 + step, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 - step, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 + step, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2171,8 +2176,8 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_epsilon, maya_stepped_tangent_sign
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
-	opts.timestep_relative = 0.05;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION;
+	opts.step_custom_epsilon = 0.05;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -2181,48 +2186,16 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_epsilon, maya_stepped_tangent_sign
 
 	const double epsilon = 1.0 + 0.05;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ -2.0, { -3.0f } },
-		{ -1.0 * epsilon, { -3.0f } },
-		{ -1.0, { -2.0f } },
-		{ -1.0 / epsilon, { -1.0f } },
-		{ -0.1, { -1.0f } },
-		{ 0.1, { 1.0f } },
-		{ 1.0 / epsilon, { 1.0f } },
-		{ 1.0, { 2.0f } },
-		{ 1.0 * epsilon, { 3.0f } },
-		{ 2.0, { 3.0f } },
-	};
-
-	ufbxt_assert(bake->nodes.count == 1);
-	ufbx_baked_node *node = &bake->nodes.data[0];
-	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
-
-	ufbx_free_baked_anim(bake);
-}
-#endif
-
-UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_float, maya_stepped_tangent_sign)
-#if UFBXT_IMPL
-{
-	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_FLOAT;
-
-	ufbx_error error;
-	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
-	if (!bake) ufbxt_log_error(&error);
-	ufbxt_assert(bake);
-
-	ufbx_baked_vec3 translation_ref[] = {
-		{ -2.0, { -3.0f } },
-		{ nextafterf(-1.0f, -INFINITY), { -3.0f } },
-		{ -1.0, { -2.0f } },
-		{ nextafterf(-1.0f, +INFINITY), { -1.0f } },
-		{ -0.1, { -1.0f } },
-		{ 0.1, { 1.0f } },
-		{ nextafterf(1.0f, -INFINITY), { 1.0f } },
-		{ 1.0, { 2.0f } },
-		{ nextafterf(1.0f, +INFINITY), { 3.0f } },
-		{ 2.0, { 3.0f } },
+		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 * epsilon, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 / epsilon, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 / epsilon, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 * epsilon, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2237,8 +2210,8 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_huge_step, maya_stepped_tangent_si
 #if UFBXT_IMPL
 {
 	ufbx_bake_opts opts = { 0 };
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
-	opts.timestep_absolute = 0.25;
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION;
+	opts.step_custom_duration = 0.25;
 
 	ufbx_error error;
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
@@ -2247,16 +2220,79 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_huge_step, maya_stepped_tangent_si
 
 	double step = 0.25;
 	ufbx_baked_vec3 translation_ref[] = {
-		{ -2.0, { -3.0f } },
-		{ -1.0 - step, { -3.0f } },
-		{ -1.0, { -2.0f } },
-		{ -1.0 + step, { -1.0f } },
-		{ 0.1 - step, { -1.0f } },
-		{ 0.1, { 1.0f } },
-		{ 1.0 - step, { 1.0f } },
-		{ 1.0, { 2.0f } },
-		{ 1.0 + step, { 3.0f } },
-		{ 2.0, { 3.0f } },
+		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 - step, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0 + step, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 - step, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0 + step, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST(maya_late_stepped_tangents)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 80.0/24.0, { -3.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(85.0/24.0, -INFINITY), { -3.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 85.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(85.0/24.0, INFINITY), { 0.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 90.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(90.0/24.0, INFINITY), { 1.0 },  UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 95.0/24.0, { 1.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(100.0/24.0, -INFINITY), { 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 100.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_ALT(maya_late_stepped_tangents_trim, maya_late_stepped_tangents)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
+	opts.trim_start_time = true;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { -3.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(5.0/24.0, -INFINITY), { -3.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(5.0/24.0, INFINITY), { 0.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 10.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10.0/24.0, INFINITY), { 1.0 },  UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 1.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(20.0/24.0, -INFINITY), { 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 20.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2274,7 +2310,6 @@ UFBXT_FILE_TEST(maya_anim_diffuse_curve)
 
 	ufbx_bake_opts opts = { 0 };
 	opts.resample_rate = 24.0;
-	opts.timestep = UFBX_BAKE_TIMESTEP_DOUBLE;
 
 	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
 	if (!bake) ufbxt_log_error(&error);
@@ -2295,18 +2330,18 @@ UFBXT_FILE_TEST(maya_anim_diffuse_curve)
 	ufbxt_assert(!strcmp(prop->name.data, "DiffuseColor"));
 
 	ufbx_baked_vec3 diffuse_ref[] = {
-		{ 0.0/24.0, { 0.0f, 0.5f, 0.5f } },
-		{ 4.0/24.0, { 1.0f, 0.5f, 0.5f } },
-		{ nextafter(6.0/24.0, -INFINITY), { 1.0f, 0.5f, 0.5f } },
-		{ 6.0/24.0, { 0.75f, 0.5f, 0.5f } },
-		{ 7.0/24.0, { 0.415319f, 0.5f, 0.5f } },
-		{ 8.0/24.0, { 0.795f, 0.5f, 0.5f } },
-		{ 9.0/24.0, { 1.152243f, 0.5f, 0.5f } },
-		{ 10.0/24.0, { 0.75f, 0.5f, 0.5f } },
-		{ nextafter(10.0/24.0, INFINITY), { 0.25f, 0.5f, 0.5f } },
-		{ 12.0/24.0, { 0.25f, 0.5f, 0.5f } },
-		{ 13.0/24.0, { 0.75f, 0.5f, 0.5f } },
-		{ 14.0/24.0, { 0.0f, 0.5f, 0.5f } },
+		{ 0.0/24.0, { 0.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 4.0/24.0, { 1.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 6.0/24.0 - 0.001, { 1.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 6.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 7.0/24.0, { 0.415319f, 0.5f, 0.5f }, 0 },
+		{ 8.0/24.0, { 0.795f, 0.5f, 0.5f }, 0 },
+		{ 9.0/24.0, { 1.152243f, 0.5f, 0.5f }, 0 },
+		{ 10.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0 + 0.001, { 0.25f, 0.5f, 0.5f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 12.0/24.0, { 0.25f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 13.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 14.0/24.0, { 0.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	ufbxt_diff_baked_vec3(err, diffuse_ref, prop->keys);
@@ -2402,13 +2437,13 @@ UFBXT_FILE_TEST(maya_anim_pivot_rotate)
 	ufbx_error error;
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1.0/24.0, { 0.0f, 0.066987f, -0.250f } },
 		{ 2.0/24.0, { 0.0f, 0.250f, -0.433f } },
 		{ 3.0/24.0, { 0.0f, 0.5f, -0.5f } },
 		{ 4.0/24.0, { 0.0f, 0.75f, -0.433f } },
 		{ 5.0/24.0, { 0.0f, 0.933013f, -0.250f } },
-		{ 6.0/24.0, { 0.0f, 1.0f, 0.0f } },
+		{ 6.0/24.0, { 0.0f, 1.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
 	{
@@ -2429,8 +2464,8 @@ UFBXT_FILE_TEST(maya_anim_pivot_rotate)
 		ufbxt_assert(!strcmp(ref_node->name.data, "pCube1"));
 
 		ufbx_baked_vec3 rotation_ref[] = {
-			{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
-			{ 6.0/24.0, { 180.0f, 0.0f, 0.0f } },
+			{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+			{ 6.0/24.0, { 180.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		};
 
 		ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
@@ -2456,13 +2491,13 @@ UFBXT_FILE_TEST(maya_anim_pivot_rotate)
 		ufbxt_assert(!strcmp(ref_node->name.data, "pCube1"));
 
 		ufbx_baked_vec3 rotation_ref[] = {
-			{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
+			{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 			{ 1.0/24.0, { 30.0f, 0.0f, 0.0f } },
 			{ 2.0/24.0, { 60.0f, 0.0f, 0.0f } },
 			{ 3.0/24.0, { 90.0f, 0.0f, 0.0f } },
 			{ 4.0/24.0, { 120.0f, 0.0f, 0.0f } },
 			{ 5.0/24.0, { 150.0f, 0.0f, 0.0f } },
-			{ 6.0/24.0, { 180.0f, 0.0f, 0.0f } },
+			{ 6.0/24.0, { 180.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		};
 
 		ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1805,6 +1805,7 @@ static void ufbxt_diff_baked_vec3_imp(ufbxt_diff_error *err, const ufbx_baked_ve
 		ufbx_baked_vec3 ref = refs[i];
 		ufbx_baked_vec3 key = list.data[i];
 
+		if (key.time != ref.time) ufbxt_logf("key.time=%f, ref.time=%f", key.time, ref.time);
 		ufbxt_assert(key.time == ref.time);
 		ufbxt_assert_close_vec3(err, key.value, ref.value);
 	}
@@ -1821,6 +1822,7 @@ static void ufbxt_diff_baked_quat_imp(ufbxt_diff_error *err, const ufbx_baked_ve
 
 		ufbx_vec3 key_euler = ufbx_quat_to_euler(key.value, UFBX_ROTATION_ORDER_XYZ);
 
+		if (key.time != ref.time) ufbxt_logf("key.time=%f, ref.time=%f", key.time, ref.time);
 		ufbxt_assert(key.time == ref.time);
 		ufbxt_assert_close_vec3(err, key_euler, ref.value);
 	}

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1853,7 +1853,7 @@ UFBXT_FILE_TEST(maya_anim_linear)
 		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(12.0/24.0, -INFINITY), { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(12.0/24.0, INFINITY), { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -1879,7 +1879,7 @@ UFBXT_FILE_TEST_ALT(maya_anim_linear_default, maya_anim_linear)
 		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 12.0/24.0 - 0.001, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 12.0/24.0 + 0.001, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -1910,23 +1910,23 @@ UFBXT_FILE_TEST(maya_huge_stepped_tangents)
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(10.0, -INFINITY), { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(10.0, +INFINITY), { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(100.0, -INFINITY), { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(100.0, +INFINITY), { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(1000.0, -INFINITY), { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(1000.0, +INFINITY), { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(10000.0, -INFINITY), { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(10000.0, +INFINITY), { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(100000.0, -INFINITY), { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(100000.0, +INFINITY), { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -1957,23 +1957,23 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_identical, maya_huge_stepped_tang
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10.0, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100.0, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100.0, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1000.0, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1000.0, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10000.0, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10000.0, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100000.0, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2003,23 +2003,23 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_default, maya_huge_stepped_tangen
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10000.0 / epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10000.0 * epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0 / epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100000.0 * epsilon, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2054,23 +2054,23 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_custom, maya_huge_stepped_tangent
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1000.0 / epsilon, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1000.0 * epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10000.0 / epsilon, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10000.0 * epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0 / epsilon, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100000.0 * epsilon, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2098,20 +2098,20 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_custom, maya_huge_stepped_ta
 	const double step = 100.0;
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10000.0 - step, { 6.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10000.0 + step, { 8.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0 - step, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100000.0 + step, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2139,23 +2139,23 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_resample, maya_huge_stepped_
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_REDUCED },
-		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_REDUCED },
-		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_REDUCED },
-		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 10000.0 - step, { 6.0f }, UFBX_BAKED_KEY_REDUCED },
-		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10000.0 + step, { 8.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0 - step, { 8.0f }, UFBX_BAKED_KEY_REDUCED },
-		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 100000.0 + step, { 10.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2182,12 +2182,12 @@ UFBXT_FILE_TEST(maya_stepped_tangent_sign)
 	ufbx_baked_vec3 translation_ref[] = {
 		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(-1.0, -INFINITY), { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(-1.0, +INFINITY), { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(1.0, -INFINITY), { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(1.0, +INFINITY), { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2214,12 +2214,12 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_default, maya_stepped_tangent_sign
 	ufbx_baked_vec3 translation_ref[] = {
 		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ -1.0 - step, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ -1.0 + step, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1.0 - step, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1.0 + step, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2248,12 +2248,12 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_epsilon, maya_stepped_tangent_sign
 	ufbx_baked_vec3 translation_ref[] = {
 		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ -1.0 * epsilon, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ -1.0 / epsilon, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1.0 / epsilon, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1.0 * epsilon, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2282,12 +2282,12 @@ UFBXT_FILE_TEST_ALT(maya_stepped_tangent_sign_huge_step, maya_stepped_tangent_si
 	ufbx_baked_vec3 translation_ref[] = {
 		{ -2.0, { -3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ -1.0 - step, { -3.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ -1.0, { -2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ -1.0 + step, { -1.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ -0.1, { -1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 0.1, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 1.0 - step, { 1.0f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 1.0 + step, { 3.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 2.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2314,13 +2314,13 @@ UFBXT_FILE_TEST(maya_late_stepped_tangents)
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 80.0/24.0, { -3.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(85.0/24.0, -INFINITY), { -3.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 85.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 85.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(85.0/24.0, INFINITY), { 0.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
-		{ 90.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ 90.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(90.0/24.0, INFINITY), { 1.0 },  UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 95.0/24.0, { 1.0 },  UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(100.0/24.0, -INFINITY), { 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 100.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2346,13 +2346,13 @@ UFBXT_FILE_TEST_ALT(maya_late_stepped_tangents_trim, maya_late_stepped_tangents)
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0/24.0, { -3.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(5.0/24.0, -INFINITY), { -3.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { -1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(5.0/24.0, INFINITY), { 0.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
-		{ 10.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 0.0 },  UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(10.0/24.0, INFINITY), { 1.0 },  UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 1.0 },  UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(20.0/24.0, -INFINITY), { 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 20.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 20.0/24.0, { 2.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 	};
 
 	ufbxt_assert(bake->nodes.count == 1);
@@ -2393,11 +2393,11 @@ UFBXT_FILE_TEST(maya_anim_diffuse_curve)
 		{ 0.0/24.0, { 0.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 4.0/24.0, { 1.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 6.0/24.0 - 0.001, { 1.0f, 0.5f, 0.5f }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 6.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 6.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 7.0/24.0, { 0.415319f, 0.5f, 0.5f }, 0 },
 		{ 8.0/24.0, { 0.795f, 0.5f, 0.5f }, 0 },
 		{ 9.0/24.0, { 1.152243f, 0.5f, 0.5f }, 0 },
-		{ 10.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0 + 0.001, { 0.25f, 0.5f, 0.5f }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 12.0/24.0, { 0.25f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 13.0/24.0, { 0.75f, 0.5f, 0.5f }, UFBX_BAKED_KEY_KEYFRAME },
@@ -2497,13 +2497,13 @@ UFBXT_FILE_TEST(maya_anim_pivot_rotate)
 	ufbx_error error;
 
 	ufbx_baked_vec3 translation_ref[] = {
-		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
 		{ 1.0/24.0, { 0.0f, 0.066987f, -0.250f } },
 		{ 2.0/24.0, { 0.0f, 0.250f, -0.433f } },
 		{ 3.0/24.0, { 0.0f, 0.5f, -0.5f } },
 		{ 4.0/24.0, { 0.0f, 0.75f, -0.433f } },
 		{ 5.0/24.0, { 0.0f, 0.933013f, -0.250f } },
-		{ 6.0/24.0, { 0.0f, 1.0f, 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 6.0/24.0, { 0.0f, 1.0f, 0.0f } },
 	};
 
 	{
@@ -2930,8 +2930,8 @@ UFBXT_FILE_TEST_OPTS(maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
 	ufbx_baked_vec3 scale_ref[] = {
 		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 5.0/24.0 - 0.001, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0 + 0.001, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2939,8 +2939,8 @@ UFBXT_FILE_TEST_OPTS(maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0/24.0, { 10.0 }, 0 },
 		{ 5.0/24.0 - 0.001, { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 15.0 }, 0 },
-		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 5.0/24.0, { 15.0 }, UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 20.0 }, UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0 + 0.001, { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 25.0 }, 0 },
 	};
@@ -2976,8 +2976,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_identical, maya_scale_no_inh
 	ufbx_baked_vec3 scale_ref[] = {
 		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 5.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -2985,8 +2985,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_identical, maya_scale_no_inh
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0/24.0, { 10.0 }, 0 },
 		{ 5.0/24.0, { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 15.0 }, 0 },
-		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 5.0/24.0, { 15.0 }, UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 20.0 }, UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0, { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 25.0 }, 0 },
 	};
@@ -3022,8 +3022,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_adjacent, maya_scale_no_inhe
 	ufbx_baked_vec3 scale_ref[] = {
 		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ nextafter(5.0/24.0, -INFINITY), { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(10.0/24.0, INFINITY), { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -3031,8 +3031,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_adjacent, maya_scale_no_inhe
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0/24.0, { 10.0 }, 0 },
 		{ nextafter(5.0/24.0, -INFINITY), { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
-		{ 5.0/24.0, { 15.0 }, 0 },
-		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 5.0/24.0, { 15.0 }, UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 20.0 }, UFBX_BAKED_KEY_STEP_KEY },
 		{ nextafter(10.0/24.0, INFINITY), { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
 		{ 15.0/24.0, { 25.0 }, 0 },
 	};
@@ -3069,8 +3069,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_resmaple, maya_scale_no_inhe
 	ufbx_baked_vec3 scale_ref[] = {
 		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 5.0/24.0 - step, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_REDUCED },
-		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
-		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0 + step, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_REDUCED },
 		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
 	};
@@ -3078,8 +3078,8 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_resmaple, maya_scale_no_inhe
 	ufbx_baked_vec3 translation_ref[] = {
 		{ 0.0/24.0, { 10.0 }, 0 },
 		{ 5.0/24.0 - step, { 10.0 }, 0 },
-		{ 5.0/24.0, { 15.0 }, 0 },
-		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 5.0/24.0, { 15.0 }, UFBX_BAKED_KEY_STEP_KEY },
+		{ 10.0/24.0, { 20.0 }, UFBX_BAKED_KEY_STEP_KEY },
 		{ 10.0/24.0 + step, { 25.0 }, 0 },
 		{ 15.0/24.0, { 25.0 }, 0 },
 	};
@@ -3096,6 +3096,95 @@ UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_resmaple, maya_scale_no_inhe
 	ufbxt_assert(joint2);
 	ufbxt_diff_baked_vec3(err, scale_ref, joint1_helper->scale_keys);
 	ufbxt_diff_baked_vec3(err, translation_ref, joint2->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST(maya_keyframe_offset)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.resample_rate = 30.0;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 rotation_ref[] = {
+		{ 0.0/30.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0/30.0, { 0.0f, 0.0f, -3.867188f } },
+		{ 2.0/30.0, { 0.0f, 0.0f, -14.0625f } },
+		{ 3.0/30.0, { 0.0f, 0.0f, -28.476563f } },
+		{ 4.0/30.0, { 0.0f, 0.0f, -45.0f } },
+		{ 5.0/30.0, { 0.0f, 0.0f, -61.523438f } },
+		{ 6.0/30.0, { 0.0f, 0.0f, -75.9375f }, },
+		{ 7.0/30.0, { 0.0f, 0.0f, -86.132813f }, },
+		{ 8.0/30.0, { 0.0f, 0.0f, -90.0f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	// FBX representation of 6401/48000
+	double mid_time = 6159116611.0/46186158000.0;
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/30.0, { 0.000000f, 2.000000f, 0.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1.0/30.0, { 0.134888f, 1.995446f, 0.249960f }, 0 },
+		{ 2.0/30.0, { 0.485960f, 1.940062f, 0.499921f }, 0 },
+		{ 3.0/30.0, { 0.953598f, 1.758024f, 0.749882f }, 0 },
+		{ mid_time, { 1.414473f, 1.413953f, 1.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/30.0, { 1.758024f, 0.953598f, 1.499765f }, 0 },
+		{ 6.0/30.0, { 1.940062f, 0.485960f, 1.999843f }, 0 },
+		{ 7.0/30.0, { 1.995446f, 0.134888f, 2.499921f }, 0 },
+		{ 8.0/30.0, { 2.000000f, 0.000000f, 3.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_quat(err, rotation_ref, node->rotation_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST(maya_keyframe_offset_step)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.resample_rate = 30.0;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 rotation_ref[] = {
+		{ 0.0/30.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 4.0/30.0 - 0.001, { 0.0f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 4.0/30.0, { 0.0f, 0.0f, -45.0f }, UFBX_BAKED_KEY_KEYFRAME|UFBX_BAKED_KEY_STEP_KEY },
+		{ 5.0/30.0, { 0.0f, 0.0f, -52.253807f } },
+		{ 6.0/30.0, { 0.0f, 0.0f, -67.697828f }, },
+		{ 7.0/30.0, { 0.0f, 0.0f, -83.042936f }, },
+		{ 8.0/30.0, { 0.0f, 0.0f, -90.0f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	// FBX representation of 6401/48000
+	double mid_time = 6159116611.0/46186158000.0;
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/30.0, { 0.000000f, 2.000000f, 0.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 4.0/30.0 - 0.001, { 0.000000f, 2.000000f, 0.999843f }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 4.0/30.0, { 1.414213f, 1.414213f, 0.999843f }, UFBX_BAKED_KEY_STEP_KEY },
+		{ mid_time, { 1.414219f, 1.414207f, 1.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/30.0, { 1.581460f, 1.224329f, 1.499765f }, 0 },
+		{ 6.0/30.0, { 1.850390f, 0.758982f, 1.999843f }, 0 },
+		{ 7.0/30.0, { 1.985274f, 0.242251f, 2.499921f }, 0 },
+		{ 8.0/30.0, { 2.000000f, 0.000000f, 3.000000f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_quat(err, rotation_ref, node->rotation_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
 
 	ufbx_free_baked_anim(bake);
 }

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1835,8 +1835,11 @@ static void ufbxt_diff_baked_quat_imp(ufbxt_diff_error *err, const ufbx_baked_ve
 UFBXT_FILE_TEST(maya_anim_linear)
 #if UFBXT_IMPL
 {
+	ufbx_bake_opts opts = { 0 };
+	opts.no_minimum_timestep = true;
+
 	ufbx_error error;
-	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, NULL, &error);
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
 	if (!bake) ufbxt_log_error(&error);
 	ufbxt_assert(bake);
 
@@ -1847,6 +1850,32 @@ UFBXT_FILE_TEST(maya_anim_linear)
 		{ nextafter(12.0/24.0, -INFINITY), { 2.0f, 0.0f, 0.0f } },
 		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f } },
 		{ nextafter(12.0/24.0, INFINITY), { 2.0f, 0.0f, 0.0f } },
+		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f } },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_ALT(maya_anim_linear_minimum_timestep, maya_anim_linear)
+#if UFBXT_IMPL
+{
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, NULL, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 0.0f, 0.0f, 0.0f } },
+		{ 2.0/24.0, { 0.5f, 2.0f, 0.0f } },
+		{ 8.0/24.0, { 2.0f, 0.0f, 0.0f } },
+		{ 12.0/24.0 - 0.001, { 2.0f, 0.0f, 0.0f } },
+		{ 12.0/24.0, { 2.0f, 0.0f, 2.0f } },
+		{ 12.0/24.0 + 0.001, { 2.0f, 0.0f, 0.0f } },
 		{ 14.0/24.0, { 2.0f, 0.0f, 0.0f } },
 	};
 

--- a/test/test_animation.h
+++ b/test/test_animation.h
@@ -1888,6 +1888,10 @@ UFBXT_FILE_TEST_ALT(maya_anim_linear_default, maya_anim_linear)
 	ufbx_baked_node *node = &bake->nodes.data[0];
 	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
 
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(12.0/24.0, -INFINITY)).z == 0.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, 12.0/24.0).z == 2.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(12.0/24.0, INFINITY)).z == 0.0f);
+
 	ufbx_free_baked_anim(bake);
 }
 #endif
@@ -1930,6 +1934,10 @@ UFBXT_FILE_TEST(maya_huge_stepped_tangents)
 	ufbxt_assert(bake->nodes.count == 1);
 	ufbx_baked_node *node = &bake->nodes.data[0];
 	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, -INFINITY)).x == 0.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, 10.0).x == 1.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, INFINITY)).x == 2.0f);
 
 	ufbx_free_baked_anim(bake);
 }
@@ -1974,6 +1982,10 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_identical, maya_huge_stepped_tang
 	ufbx_baked_node *node = &bake->nodes.data[0];
 	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
 
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, -INFINITY)).x == 0.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, 10.0).x == 1.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, INFINITY)).x == 2.0f);
+
 	ufbx_free_baked_anim(bake);
 }
 #endif
@@ -2015,6 +2027,10 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_default, maya_huge_stepped_tangen
 	ufbxt_assert(bake->nodes.count == 1);
 	ufbx_baked_node *node = &bake->nodes.data[0];
 	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, -INFINITY)).x == 0.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, 10.0).x == 1.0f);
+	ufbxt_assert(ufbx_evaluate_baked_vec3(node->translation_keys, nextafter(10.0, INFINITY)).x == 2.0f);
 
 	ufbx_free_baked_anim(bake);
 }
@@ -2097,6 +2113,50 @@ UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_custom, maya_huge_stepped_ta
 		{ 100000.0 - step, { 8.0f }, UFBX_BAKED_KEY_STEP_LEFT },
 		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
 		{ 100000.0 + step, { 10.0f }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbxt_assert(bake->nodes.count == 1);
+	ufbx_baked_node *node = &bake->nodes.data[0];
+	ufbxt_diff_baked_vec3(err, translation_ref, node->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_ALT(maya_huge_stepped_tangents_huge_resample, maya_huge_stepped_tangents)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.maximum_sample_rate = 100.0;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	const double step = 1.0 / 100.0;
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0, { 0.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 - step, { 0.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 10.0, { 1.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0 + step, { 2.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 20.0, { 2.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 - step, { 2.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 100.0, { 3.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100.0 + step, { 4.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 200.0, { 4.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 - step, { 4.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 1000.0, { 5.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 1000.0 + step, { 6.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 2000.0, { 6.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 - step, { 6.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 10000.0, { 7.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10000.0 + step, { 8.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 20000.0, { 8.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 - step, { 8.0f }, UFBX_BAKED_KEY_REDUCED },
+		{ 100000.0, { 9.0f }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 100000.0 + step, { 10.0f }, UFBX_BAKED_KEY_REDUCED },
 		{ 200000.0, { 10.0f }, UFBX_BAKED_KEY_KEYFRAME },
 	};
 
@@ -2844,3 +2904,200 @@ UFBXT_FILE_TEST(maya_keyframe_spacing)
 	}
 }
 #endif
+
+#if UFBXT_IMPL
+static ufbx_baked_node *ufbxt_find_baked_node(ufbx_baked_anim *bake, ufbx_node *node)
+{
+	for (size_t i = 0; i < bake->nodes.count; i++) {
+		if (bake->nodes.data[i].typed_id == node->typed_id) {
+			return &bake->nodes.data[i];
+		}
+	}
+	return NULL;
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS(maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 scale_ref[] = {
+		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0 - 0.001, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0 + 0.001, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 10.0 }, 0 },
+		{ 5.0/24.0 - 0.001, { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 15.0 }, 0 },
+		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 10.0/24.0 + 0.001, { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 25.0 }, 0 },
+	};
+
+	ufbx_node *joint1_node = ufbx_find_node(scene, "joint1");
+	ufbx_node *joint2_node = ufbx_find_node(scene, "joint2");
+	ufbxt_assert(joint1_node);
+	ufbxt_assert(joint1_node->scale_helper);
+	ufbxt_assert(joint2_node);
+
+	ufbx_baked_node *joint1_helper = ufbxt_find_baked_node(bake, joint1_node->scale_helper);
+	ufbx_baked_node *joint2 = ufbxt_find_baked_node(bake, joint2_node);
+	ufbxt_assert(joint1_helper);
+	ufbxt_assert(joint2);
+	ufbxt_diff_baked_vec3(err, scale_ref, joint1_helper->scale_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, joint2->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_identical, maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_IDENTICAL_TIME;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 scale_ref[] = {
+		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 10.0 }, 0 },
+		{ 5.0/24.0, { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 15.0 }, 0 },
+		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 10.0/24.0, { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 25.0 }, 0 },
+	};
+
+	ufbx_node *joint1_node = ufbx_find_node(scene, "joint1");
+	ufbx_node *joint2_node = ufbx_find_node(scene, "joint2");
+	ufbxt_assert(joint1_node);
+	ufbxt_assert(joint1_node->scale_helper);
+	ufbxt_assert(joint2_node);
+
+	ufbx_baked_node *joint1_helper = ufbxt_find_baked_node(bake, joint1_node->scale_helper);
+	ufbx_baked_node *joint2 = ufbxt_find_baked_node(bake, joint2_node);
+	ufbxt_assert(joint1_helper);
+	ufbxt_assert(joint2);
+	ufbxt_diff_baked_vec3(err, scale_ref, joint1_helper->scale_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, joint2->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_adjacent, maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.step_handling = UFBX_BAKE_STEP_HANDLING_ADJACENT_DOUBLE;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	ufbx_baked_vec3 scale_ref[] = {
+		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(5.0/24.0, -INFINITY), { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ nextafter(10.0/24.0, INFINITY), { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 10.0 }, 0 },
+		{ nextafter(5.0/24.0, -INFINITY), { 10.0 }, UFBX_BAKED_KEY_STEP_LEFT },
+		{ 5.0/24.0, { 15.0 }, 0 },
+		{ 10.0/24.0, { 20.0 }, 0 },
+		{ nextafter(10.0/24.0, INFINITY), { 25.0 }, UFBX_BAKED_KEY_STEP_RIGHT },
+		{ 15.0/24.0, { 25.0 }, 0 },
+	};
+
+	ufbx_node *joint1_node = ufbx_find_node(scene, "joint1");
+	ufbx_node *joint2_node = ufbx_find_node(scene, "joint2");
+	ufbxt_assert(joint1_node);
+	ufbxt_assert(joint1_node->scale_helper);
+	ufbxt_assert(joint2_node);
+
+	ufbx_baked_node *joint1_helper = ufbxt_find_baked_node(bake, joint1_node->scale_helper);
+	ufbx_baked_node *joint2 = ufbxt_find_baked_node(bake, joint2_node);
+	ufbxt_assert(joint1_helper);
+	ufbxt_assert(joint2);
+	ufbxt_diff_baked_vec3(err, scale_ref, joint1_helper->scale_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, joint2->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS_ALT(maya_scale_no_inherit_step_resmaple, maya_scale_no_inherit_step, ufbxt_scale_helper_opts)
+#if UFBXT_IMPL
+{
+	ufbx_bake_opts opts = { 0 };
+	opts.maximum_sample_rate = 100.0;
+
+	ufbx_error error;
+	ufbx_baked_anim *bake = ufbx_bake_anim(scene, NULL, &opts, &error);
+	if (!bake) ufbxt_log_error(&error);
+	ufbxt_assert(bake);
+
+	double step = 1.0 / 100.0;
+	ufbx_baked_vec3 scale_ref[] = {
+		{ 0.0/24.0, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 5.0/24.0 - step, { 2.0, 1.0, 1.0 }, UFBX_BAKED_KEY_REDUCED },
+		{ 5.0/24.0, { 3.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0, { 4.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+		{ 10.0/24.0 + step, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_REDUCED },
+		{ 15.0/24.0, { 5.0, 1.0, 1.0 }, UFBX_BAKED_KEY_KEYFRAME },
+	};
+
+	ufbx_baked_vec3 translation_ref[] = {
+		{ 0.0/24.0, { 10.0 }, 0 },
+		{ 5.0/24.0 - step, { 10.0 }, 0 },
+		{ 5.0/24.0, { 15.0 }, 0 },
+		{ 10.0/24.0, { 20.0 }, 0 },
+		{ 10.0/24.0 + step, { 25.0 }, 0 },
+		{ 15.0/24.0, { 25.0 }, 0 },
+	};
+
+	ufbx_node *joint1_node = ufbx_find_node(scene, "joint1");
+	ufbx_node *joint2_node = ufbx_find_node(scene, "joint2");
+	ufbxt_assert(joint1_node);
+	ufbxt_assert(joint1_node->scale_helper);
+	ufbxt_assert(joint2_node);
+
+	ufbx_baked_node *joint1_helper = ufbxt_find_baked_node(bake, joint1_node->scale_helper);
+	ufbx_baked_node *joint2 = ufbxt_find_baked_node(bake, joint2_node);
+	ufbxt_assert(joint1_helper);
+	ufbxt_assert(joint2);
+	ufbxt_diff_baked_vec3(err, scale_ref, joint1_helper->scale_keys);
+	ufbxt_diff_baked_vec3(err, translation_ref, joint2->translation_keys);
+
+	ufbx_free_baked_anim(bake);
+}
+#endif
+

--- a/test/test_skin.h
+++ b/test/test_skin.h
@@ -123,6 +123,45 @@ UFBXT_FILE_TEST_SUFFIX(maya_game_sausage, combined)
 }
 #endif
 
+UFBXT_FILE_TEST_ALT_SUFFIX(maya_game_sausage_combined_bake, maya_game_sausage, combined)
+#if UFBXT_IMPL
+{
+	{
+		ufbx_anim_stack *stack = ufbx_find_anim_stack(scene, "spin");
+		ufbx_baked_anim *bake = ufbx_bake_anim(scene, stack->anim, NULL, NULL);
+		ufbxt_assert(bake);
+
+		ufbxt_assert(bake->key_time_min == 20.0/24.0);
+		ufbxt_assert(bake->key_time_max == 40.0/24.0);
+
+		ufbxt_assert(bake->playback_time_begin == 20.0/24.0);
+		ufbxt_assert(bake->playback_time_end == 40.0/24.0);
+		ufbxt_assert_close_double(err, bake->playback_duration, 40.0/24.0 - 20.0/24.0);
+
+		ufbx_free_baked_anim(bake);
+	}
+
+	{
+		ufbx_anim_stack *stack = ufbx_find_anim_stack(scene, "spin");
+
+		ufbx_bake_opts opts = { 0 };
+		opts.trim_start_time = true;
+
+		ufbx_baked_anim *bake = ufbx_bake_anim(scene, stack->anim, &opts, NULL);
+		ufbxt_assert(bake);
+
+		ufbxt_assert(bake->key_time_min == 20.0/24.0);
+		ufbxt_assert(bake->key_time_max == 40.0/24.0);
+
+		ufbxt_assert(bake->playback_time_begin == 20.0/24.0);
+		ufbxt_assert(bake->playback_time_end == 40.0/24.0);
+		ufbxt_assert_close_double(err, bake->playback_duration, 40.0/24.0 - 20.0/24.0);
+
+		ufbx_free_baked_anim(bake);
+	}
+}
+#endif
+
 UFBXT_FILE_TEST(synthetic_sausage_wiggle_no_link)
 #if UFBXT_IMPL
 {

--- a/ufbx.c
+++ b/ufbx.c
@@ -230,7 +230,7 @@
 	double ufbx_fabs(double x);
 	double ufbx_copysign(double x, double y);
 	double ufbx_nextafter(double x, double y);
-	double ufbx_nextafterf(float x, float y);
+	float ufbx_nextafterf(float x, float y);
 	double ufbx_ceil(double x);
 	int ufbx_isnan(double x);
 #endif
@@ -25394,7 +25394,7 @@ static ufbxi_noinline bool ufbxi_bake_apply_epsilon(ufbxi_bake_context *bc, doub
 		if (abs_time > abs_nearby) {
 			double min_abs_time = abs_nearby * bc->epsilon_factor;
 			if (bc->epsilon_float && (float)min_abs_time == (float)abs_nearby) {
-				min_abs_time = (float)ufbx_nextafterf((float)min_abs_time, UFBX_INFINITY);
+				min_abs_time = ufbx_nextafterf((float)min_abs_time, UFBX_INFINITY);
 			}
 			if (abs_time < min_abs_time) {
 				time = sign * min_abs_time;
@@ -25403,7 +25403,7 @@ static ufbxi_noinline bool ufbxi_bake_apply_epsilon(ufbxi_bake_context *bc, doub
 		} else {
 			double max_abs_time = abs_nearby / bc->epsilon_factor;
 			if (bc->epsilon_float && (float)max_abs_time == (float)abs_nearby) {
-				max_abs_time = (float)ufbx_nextafterf((float)max_abs_time, -UFBX_INFINITY);
+				max_abs_time = ufbx_nextafterf((float)max_abs_time, -UFBX_INFINITY);
 			}
 			if (abs_time > max_abs_time) {
 				time = sign * max_abs_time;

--- a/ufbx.c
+++ b/ufbx.c
@@ -25446,7 +25446,7 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_bake_times(ufbxi_bake_c
 			double next_time = times[src++];
 			double delta = next_time - prev_time;
 			double scale = ufbx_fmax(ufbx_fabs(prev_time), ufbx_fabs(next_time));
-			double min_delta = ufbx_fmax(scale * min_rel, min_abs);
+			double min_delta = ufbx_fmax(scale * min_rel, min_abs) * 0.5f;
 
 			if (delta >= min_delta) {
 				times[dst++] = next_time;

--- a/ufbx.c
+++ b/ufbx.c
@@ -25409,13 +25409,11 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_bake_times(ufbxi_bake_c
 	ufbxi_bake_time *times = ufbxi_push_pop(&bc->tmp_prop, &bc->tmp_times, ufbxi_bake_time, num_times);
 	ufbxi_check_err(&bc->error, times);
 
-	if (num_times == 0) return 1;
-
 	// TODO: Something better
 	qsort(times, num_times, sizeof(ufbxi_bake_time), &ufbxi_cmp_bake_time_fn);
 
 	// Deduplicate times
-	{
+	if (num_times > 0) {
 		size_t dst = 0;
 		ufbxi_bake_time prev = times[0];
 		for (size_t src = 1; src < num_times; src++) {

--- a/ufbx.c
+++ b/ufbx.c
@@ -26043,7 +26043,7 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_bake_anim_prop(ufbxi_bake_contex
 		ufbx_prop prop = ufbx_evaluate_prop_len(bc->anim, element, name.data, name.length, eval_time);
 		keys.data[i].time = bake_time.time;
 		keys.data[i].value = prop.value_vec3;
-		keys.data[i].flags = bake_time.flags;
+		keys.data[i].flags = (ufbx_baked_key_flags)bake_time.flags;
 	}
 
 	ufbx_baked_prop *baked_prop = ufbxi_push_zero(&bc->tmp_props, ufbx_baked_prop, 1);

--- a/ufbx.c
+++ b/ufbx.c
@@ -553,7 +553,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 11, 2)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 12, 0)
 const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);
@@ -25477,7 +25477,6 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_bake_times(ufbxi_bake_c
 			double delta = next_time - prev_time;
 			double scale = ufbx_fmax(ufbx_fabs(prev_time), ufbx_fabs(next_time));
 			double min_delta = ufbx_fmax(scale * min_rel, min_abs);
-
 			if (delta <= min_delta) {
 				// Try to determine which time is nearer to an original keyframe and retain that
 				double prev_frame = prev_time * frame_factor;
@@ -25501,7 +25500,6 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_bake_times(ufbxi_bake_c
 			double delta = next_time - prev_time;
 			double scale = ufbx_fmax(ufbx_fabs(prev_time), ufbx_fabs(next_time));
 			double min_delta = ufbx_fmax(scale * min_rel, min_abs);
-
 			if (delta > min_delta || ufbxi_bake_check_epsilon(bc, prev_time, next_time)) {
 				times[dst++] = next_time;
 				prev_time = next_time;

--- a/ufbx.c
+++ b/ufbx.c
@@ -25420,6 +25420,8 @@ static ufbxi_noinline double ufbxi_bake_apply_epsilon(ufbxi_bake_context *bc, do
 
 static ufbxi_noinline bool ufbxi_bake_check_epsilon(ufbxi_bake_context *bc, double prev, double next)
 {
+	if (strstr("A", "A")) return true;
+
 	if (next <= prev) return false;
 	if (ufbxi_bake_apply_epsilon(bc, prev, next) == prev) return true;
 	if (ufbxi_bake_apply_epsilon(bc, next, prev) == next) return true;

--- a/ufbx.c
+++ b/ufbx.c
@@ -25293,7 +25293,7 @@ static int ufbxi_cmp_bake_prop(const void *va, const void *vb)
 
 ufbx_static_assert(bake_step_left, UFBX_BAKED_KEY_STEP_LEFT == 0x1);
 ufbx_static_assert(bake_step_right, UFBX_BAKED_KEY_STEP_RIGHT == 0x2);
-ufbx_static_assert(bake_step_right, UFBX_BAKED_KEY_STEP_KEY == 0x4);
+ufbx_static_assert(bake_step_key, UFBX_BAKED_KEY_STEP_KEY == 0x4);
 static ufbxi_forceinline int ufbxi_cmp_bake_time(ufbxi_bake_time a, ufbxi_bake_time b)
 {
 	if (a.time != b.time) return a.time < b.time ? -1 : 1;

--- a/ufbx.h
+++ b/ufbx.h
@@ -4609,6 +4609,9 @@ typedef struct ufbx_anim_opts {
 	uint32_t _end_zero;
 } ufbx_anim_opts;
 
+// Controls how close keyframe time values can be in baked animation.
+// Further adjustments for all options can be done via `ufbx_bake_opts.timestep_absolute`
+// and `ufbx_bake_opts.timestep_relative`.
 typedef enum ufbx_bake_timestep UFBX_ENUM_REPR {
 
 	// Default bake timestep: safe spacing to guard against less robust interpolation functions.
@@ -4616,13 +4619,9 @@ typedef enum ufbx_bake_timestep UFBX_ENUM_REPR {
 	UFBX_BAKE_TIMESTEP_DEFAULT,
 
 	// Key times are represented as unique `float` values.
-	// Use `ufbx_bake_opts.timestep_absolute` and `ufbx_bake_opts.timestep_relative`
-	// to control additional spacing between keyframes.
 	UFBX_BAKE_TIMESTEP_FLOAT,
 
 	// Key times are represented as unique `double` values.
-	// Use `ufbx_bake_opts.timestep_absolute` and `ufbx_bake_opts.timestep_relative`
-	// to control additional spacing between keyframes.
 	UFBX_BAKE_TIMESTEP_DOUBLE,
 
 	UFBX_ENUM_FORCE_WIDTH(UFBX_BAKE_TIMESTEP)
@@ -4684,9 +4683,9 @@ typedef struct ufbx_bake_opts {
 	double timestep_relative;
 
 	// Timestep in seconds for constant interpolation.
-	// Default of `0.0` uses the smallest representable time offset.
-	// NOTE: This offset will be clamped by minimum timestep by default,
-	// enable `ufbx_bake_opts.no_minimum_timestep` to allow close keyframes.
+	// Default of `0.0` uses the smallest representable time offset, which is determined by
+	// `ufbx_bake_opts.timestep`. On default settings this will result in `0.001` second
+	// interpolation for constant tangents, see `ufbx_bake_timestep`.
 	double constant_timestep;
 
 	// Enable key reduction.

--- a/ufbx.h
+++ b/ufbx.h
@@ -219,7 +219,7 @@ struct ufbx_converter { };
 #define ufbx_version_minor(version) ((uint32_t)(version)/1000u%1000u)
 #define ufbx_version_patch(version) ((uint32_t)(version)%1000u)
 
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 11, 2)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 12, 0)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types

--- a/ufbx.h
+++ b/ufbx.h
@@ -4704,10 +4704,6 @@ typedef struct ufbx_bake_opts {
 	// Default: `4`
 	size_t key_reduction_passes;
 
-	// Compensate for `UFBX_INHERIT_MODE_IGNORE_PARENT_SCALE` by adjusting child scale.
-	// NOTE: This is an lossy operation, and properly works only for uniform scaling.
-	bool compensate_inherit_no_scale;
-
 	uint32_t _end_zero;
 } ufbx_bake_opts;
 

--- a/ufbx.h
+++ b/ufbx.h
@@ -5113,11 +5113,13 @@ ufbx_abi void ufbx_retain_baked_anim(ufbx_baked_anim *bake);
 ufbx_abi void ufbx_free_baked_anim(ufbx_baked_anim *bake);
 
 // Evaluate baked animation `keyframes` at `time`.
-// Internally simply linearly interpolates between two adjacent keyframes.
+// Internally linearly interpolates between two adjacent keyframes.
+// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
 ufbx_abi ufbx_vec3 ufbx_evaluate_baked_vec3(ufbx_baked_vec3_list keyframes, double time);
 
 // Evaluate baked animation `keyframes` at `time`.
-// Internally simply spherically interpolates (`ufbx_quat_slerp()`) between two adjacent keyframes.
+// Internally spherically interpolates (`ufbx_quat_slerp()`) between two adjacent keyframes.
+// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
 ufbx_abi ufbx_quat ufbx_evaluate_baked_quat(ufbx_baked_quat_list keyframes, double time);
 
 // Poses

--- a/ufbx.h
+++ b/ufbx.h
@@ -4212,11 +4212,14 @@ typedef enum ufbx_baked_key_flags UFBX_FLAG_REPR {
 	UFBX_BAKED_KEY_STEP_LEFT = 0x1,
 	// This keyframe represents a constant step from the right side
 	UFBX_BAKED_KEY_STEP_RIGHT = 0x2,
+	// This keyframe is the main part of a step
+	// Bordering either `UFBX_BAKED_KEY_STEP_LEFT` or `UFBX_BAKED_KEY_STEP_RIGHT`.
+	UFBX_BAKED_KEY_STEP_KEY = 0x4,
 	// This keyframe is a real keyframe in the source animation
-	UFBX_BAKED_KEY_KEYFRAME = 0x4,
+	UFBX_BAKED_KEY_KEYFRAME = 0x8,
 	// This keyframe has been reduced by maximum sample rate.
 	// See `ufbx_bake_opts.maximum_sample_rate`.
-	UFBX_BAKED_KEY_REDUCED = 0x8,
+	UFBX_BAKED_KEY_REDUCED = 0x10,
 
 	UFBX_FLAG_FORCE_WIDTH(UFBX_BAKED_KEY)
 } ufbx_baked_key_flags;

--- a/ufbx.h
+++ b/ufbx.h
@@ -4609,6 +4609,27 @@ typedef struct ufbx_anim_opts {
 	uint32_t _end_zero;
 } ufbx_anim_opts;
 
+typedef enum ufbx_bake_timestep UFBX_ENUM_REPR {
+
+	// Default bake timestep: safe spacing to guard against less robust interpolation functions.
+	// Uses `0.001` second (1ms) spacing between keyframes and `4 * FLT_EPSILON` epsilon.
+	UFBX_BAKE_TIMESTEP_DEFAULT,
+
+	// Key times are represented as unique `float` values.
+	// Use `ufbx_bake_opts.timestep_absolute` and `ufbx_bake_opts.timestep_relative`
+	// to control additional spacing between keyframes.
+	UFBX_BAKE_TIMESTEP_FLOAT,
+
+	// Key times are represented as unique `double` values.
+	// Use `ufbx_bake_opts.timestep_absolute` and `ufbx_bake_opts.timestep_relative`
+	// to control additional spacing between keyframes.
+	UFBX_BAKE_TIMESTEP_DOUBLE,
+
+	UFBX_ENUM_FORCE_WIDTH(UFBX_BAKE_TIMESTEP)
+} ufbx_bake_timestep;
+
+UFBX_ENUM_TYPE(ufbx_bake_timestep, UFBX_BAKE_TIMESTEP, UFBX_BAKE_TIMESTEP_DOUBLE);
+
 typedef struct ufbx_bake_opts {
 	uint32_t _begin_zero;
 
@@ -4650,16 +4671,17 @@ typedef struct ufbx_bake_opts {
 	// Default: 32
 	size_t max_keyframe_segments;
 
-	// Allow timesteps to be as close in time as possible.
-	bool no_minimum_timestep;
-
 	// Controls how close keyframes are allowed to be placed.
-	// Default: `FLT_EPSILON * 4`, unless `no_minimum_timestep` is set.
-	double minimum_relative_timestep;
+	// Default maintains an 1ms spacing between keyframes and `4*FLT_EPSILON` spacing.
+	ufbx_bake_timestep timestep;
 
-	// Controls how close keyframes are allowed to be placed.
-	// Default: `0.001`, unless `no_minimum_timestep` is set.
-	double minimum_absolute_timestep;
+	// Minimum absolute timestep.
+	// Defaults to `0.001` if `timestep == UFBX_BAKE_TIMESTEP_DEFAULT`.
+	double timestep_absolute;
+
+	// Minimum relative timestep.
+	// Defaults to `4 * FLT_EPSILON` if `timestep == UFBX_BAKE_TIMESTEP_DEFAULT`.
+	double timestep_relative;
 
 	// Timestep in seconds for constant interpolation.
 	// Default of `0.0` uses the smallest representable time offset.

--- a/ufbx.h
+++ b/ufbx.h
@@ -4662,7 +4662,7 @@ typedef enum ufbx_bake_step_handling UFBX_ENUM_REPR {
 	UFBX_ENUM_FORCE_WIDTH(ufbx_bake_step_handling)
 } ufbx_bake_step_handling;
 
-UFBX_ENUM_TYPE(ufbx_bake_step_handling, ufbx_bake_step_handling, UFBX_BAKE_STEP_HANDLING_IGNORE);
+UFBX_ENUM_TYPE(ufbx_bake_step_handling, UFBX_BAKE_STEP_HANDLING, UFBX_BAKE_STEP_HANDLING_IGNORE);
 
 typedef struct ufbx_bake_opts {
 	uint32_t _begin_zero;

--- a/ufbx.h
+++ b/ufbx.h
@@ -4650,8 +4650,21 @@ typedef struct ufbx_bake_opts {
 	// Default: 32
 	size_t max_keyframe_segments;
 
+	// Allow timesteps to be as close in time as possible.
+	bool no_minimum_timestep;
+
+	// Controls how close keyframes are allowed to be placed.
+	// Default: `FLT_EPSILON * 4`, unless `no_minimum_timestep` is set.
+	double minimum_relative_timestep;
+
+	// Controls how close keyframes are allowed to be placed.
+	// Default: `0.001`, unless `no_minimum_timestep` is set.
+	double minimum_absolute_timestep;
+
 	// Timestep in seconds for constant interpolation.
 	// Default of `0.0` uses the smallest representable time offset.
+	// NOTE: This offset will be clamped by minimum timestep by default,
+	// enable `ufbx_bake_opts.no_minimum_timestep` to allow close keyframes.
 	double constant_timestep;
 
 	// Enable key reduction.


### PR DESCRIPTION
Implement minimum timestep for `ufbx_bake_anim()`.

This should guard against non-robust interpolation functions going to inf/nan for stepped tangents.