### PR TITLE
Fix .obj file space to unknown

### DIFF
--- a/test/test_obj.h
+++ b/test/test_obj.h
@@ -1508,3 +1508,89 @@ UFBXT_FILE_TEST_OPTS_ALT(synthetic_empty_face_allow, synthetic_empty_face, ufbxt
 }
 #endif
 
+UFBXT_FILE_TEST_ALT_FLAGS(obj_space_default, blender_279_ball, UFBXT_FILE_TEST_FLAG_FUZZ_ALWAYS)
+#if UFBXT_IMPL
+{
+	if (scene->metadata.file_format == UFBX_FILE_FORMAT_OBJ) {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_UNKNOWN);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_UNKNOWN);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_UNKNOWN);
+		ufbxt_assert(scene->settings.unit_meters == 0.0f);
+		ufbxt_assert(scene->settings.original_unit_meters == 0.0f);
+	} else {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Y);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+		ufbxt_assert(scene->settings.unit_meters == (ufbx_real)0.01);
+		ufbxt_assert(scene->settings.original_unit_meters == (ufbx_real)0.01);
+	}
+}
+#endif
+
+#if UFBXT_IMPL
+static ufbx_load_opts obj_axes_opts()
+{
+	ufbx_load_opts opts = { 0 };
+	opts.obj_unit_meters = (ufbx_real)0.1;
+	opts.obj_axes = ufbx_axes_right_handed_z_up;
+	return opts;
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS_ALT_FLAGS(obj_space_manual_axes, blender_279_ball, obj_axes_opts, UFBXT_FILE_TEST_FLAG_FUZZ_ALWAYS)
+#if UFBXT_IMPL
+{
+	if (scene->metadata.file_format == UFBX_FILE_FORMAT_OBJ) {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_NEGATIVE_Y);
+		ufbxt_assert(scene->settings.unit_meters == (ufbx_real)0.1);
+		ufbxt_assert(scene->settings.original_unit_meters == (ufbx_real)0.1);
+	} else {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Y);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+		ufbxt_assert(scene->settings.unit_meters == (ufbx_real)0.01);
+		ufbxt_assert(scene->settings.original_unit_meters == (ufbx_real)0.01);
+	}
+}
+#endif
+
+#if UFBXT_IMPL
+static ufbx_load_opts obj_axes_convert_opts()
+{
+	ufbx_load_opts opts = { 0 };
+	opts.obj_unit_meters = (ufbx_real)0.1;
+	opts.obj_axes = ufbx_axes_right_handed_z_up;
+	opts.target_unit_meters = 1.0f;
+	opts.target_axes = ufbx_axes_right_handed_y_up;
+	return opts;
+}
+#endif
+
+UFBXT_FILE_TEST_OPTS_ALT_FLAGS(obj_space_manual_convert, blender_279_ball, obj_axes_convert_opts, UFBXT_FILE_TEST_FLAG_FUZZ_ALWAYS)
+#if UFBXT_IMPL
+{
+	if (scene->metadata.file_format == UFBX_FILE_FORMAT_OBJ) {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_NEGATIVE_Y);
+		ufbxt_assert(scene->settings.unit_meters == (ufbx_real)0.1);
+		ufbxt_assert(scene->settings.original_unit_meters == (ufbx_real)0.1);
+
+		ufbx_node *node = scene->root_node;
+		ufbx_vec3 scale = { 0.1f, 0.1f, 0.1f };
+		ufbx_quat 
+
+		ufbxt_assert_close_vec3(err, node->local_transform.scale, scale);
+		ufbxt_assert_close_vec3(err, node->local_transform.scale, scale);
+	} else {
+		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Y);
+		ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+		ufbxt_assert(scene->settings.unit_meters == (ufbx_real)0.01);
+		ufbxt_assert(scene->settings.original_unit_meters == (ufbx_real)0.01);
+	}
+}
+#endif
+

--- a/test/test_obj.h
+++ b/test/test_obj.h
@@ -1580,10 +1580,11 @@ UFBXT_FILE_TEST_OPTS_ALT_FLAGS(obj_space_manual_convert, blender_279_ball, obj_a
 
 		ufbx_node *node = scene->root_node;
 		ufbx_vec3 scale = { 0.1f, 0.1f, 0.1f };
-		ufbx_quat 
+		ufbx_vec3 euler = { -90.0f, 0.0f, 0.0f };
+		ufbx_quat rotation = ufbx_euler_to_quat(euler, UFBX_ROTATION_ORDER_XYZ);
 
 		ufbxt_assert_close_vec3(err, node->local_transform.scale, scale);
-		ufbxt_assert_close_vec3(err, node->local_transform.scale, scale);
+		ufbxt_assert_close_quat(err, node->local_transform.rotation, rotation);
 	} else {
 		ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
 		ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Y);

--- a/ufbx.c
+++ b/ufbx.c
@@ -22783,6 +22783,19 @@ static ufbxi_noinline void ufbxi_update_scene_settings(ufbx_scene_settings *sett
 	}
 }
 
+static ufbxi_noinline void ufbxi_update_scene_settings_obj(ufbxi_context *uc)
+{
+	ufbx_scene_settings *settings = &uc->scene.settings;
+	settings->original_unit_meters = settings->unit_meters = uc->opts.obj_unit_meters;
+	if (ufbx_coordinate_axes_valid(uc->opts.obj_axes)) {
+		settings->axes = uc->opts.obj_axes;
+	} else {
+		settings->axes.right = UFBX_COORDINATE_AXIS_UNKNOWN;
+		settings->axes.up = UFBX_COORDINATE_AXIS_UNKNOWN;
+		settings->axes.front = UFBX_COORDINATE_AXIS_UNKNOWN;
+	}
+}
+
 // -- Geometry caches
 
 #if UFBXI_FEATURE_GEOMETRY_CACHE
@@ -24126,6 +24139,9 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_load_imp(ufbxi_context *uc)
 	ufbxi_check(ufbxi_finalize_scene(uc));
 
 	ufbxi_update_scene_settings(&uc->scene.settings);
+	if (uc->scene.metadata.file_format == UFBX_FILE_FORMAT_OBJ) {
+		ufbxi_update_scene_settings_obj(uc);
+	}
 
 	// Axis conversion
 	if (ufbx_coordinate_axes_valid(uc->opts.target_axes)) {

--- a/ufbx.h
+++ b/ufbx.h
@@ -4739,6 +4739,16 @@ typedef struct ufbx_load_opts {
 	// (.obj) Data for the .mtl file.
 	ufbx_blob obj_mtl_data;
 
+	// The world unit in meters that .obj files are assumed to be in.
+	// .obj files do not define the working units. By default the unit scale
+	// is read as zero, and no unit conversion is performed.
+	ufbx_real obj_unit_meters;
+
+	// Coordinate space .obj files are assumed to be in.
+	// .obj files do not define the coordinate space they use. By default no
+	// coordinate space is assumed and no conversion is performed.
+	ufbx_coordinate_axes obj_axes;
+
 	uint32_t _end_zero;
 } ufbx_load_opts;
 


### PR DESCRIPTION
Currently .obj files import as cm units, this PR will change them to import as an unknown space.

Fixes #124 