### PR TITLE
Fix baking scenes with mirrored coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           path: build/hashdump_ci_windows.txt.gz
 
   ci_macos:
-    runs-on: macos-11
+    runs-on: macos-14
     needs: ci_pre_hashes
     steps:
       - uses: actions/checkout@v3

--- a/test/test_skin.h
+++ b/test/test_skin.h
@@ -792,6 +792,8 @@ UFBXT_TEST(max_transformed_skin_lefthanded)
 			ufbxt_check_frame(scene, &err, false, "max_transformed_skin_lefthanded_5", NULL, 5.0/30.0);
 			ufbxt_check_frame(scene, &err, false, "max_transformed_skin_lefthanded_15", NULL, 15.0/30.0);
 
+			ufbxt_check_transform_consistency(&err, scene, 30.0, 30);
+
 			ufbx_free_scene(scene);
 		}
 	}
@@ -825,6 +827,8 @@ UFBXT_TEST(max_transformed_skin_lefthanded_adjust)
 			ufbxt_check_scene(scene);
 			ufbxt_check_frame(scene, &err, false, "max_transformed_skin_lefthanded_5", NULL, 5.0/30.0);
 			ufbxt_check_frame(scene, &err, false, "max_transformed_skin_lefthanded_15", NULL, 15.0/30.0);
+
+			ufbxt_check_transform_consistency(&err, scene, 30.0, 30);
 
 			ufbx_free_scene(scene);
 		}

--- a/ufbx.c
+++ b/ufbx.c
@@ -21772,6 +21772,10 @@ ufbxi_noinline static ufbx_quat ufbxi_get_rotation(const ufbx_props *props, ufbx
 		ufbxi_mul_rotate_quat(&t, node->adjust_pre_rotation);
 	}
 
+	if (node->adjust_mirror_axis) {
+		ufbxi_mirror_rotation(&t.rotation, node->adjust_mirror_axis);
+	}
+
 	return t.rotation;
 }
 

--- a/ufbx.c
+++ b/ufbx.c
@@ -7257,8 +7257,8 @@ typedef enum {
 } ufbxi_parse_state;
 
 typedef enum {
-	UFBXI_ARRAY_FLAG_RESULT       = 0x1, // < Alloacte the array from the result buffer
-	UFBXI_ARRAY_FLAG_TMP_BUF      = 0x2, // < Alloacte the array from the result buffer
+	UFBXI_ARRAY_FLAG_RESULT       = 0x1, // < Allocate the array from the result buffer
+	UFBXI_ARRAY_FLAG_TMP_BUF      = 0x2, // < Allocate the array from the result buffer
 	UFBXI_ARRAY_FLAG_PAD_BEGIN    = 0x4, // < Pad the begin of the array with 4 zero elements to guard from invalid -1 index accesses
 	UFBXI_ARRAY_FLAG_ACCURATE_F32 = 0x8, // < Must be parsed as bit-accurate 32-bit floats
 } ufbxi_array_flags;
@@ -24714,7 +24714,7 @@ static ufbxi_noinline const ufbx_prop *ufbxi_next_prop_slow(ufbxi_prop_iter *ite
 	const ufbx_prop_override *over = iter->over;
 	if (prop == iter->prop_end && over == iter->over_end) return NULL;
 
-	// We can use `UINT32_MAX` as a termianting key (aka prefix) as prop names must
+	// We can use `UINT32_MAX` as a terminating key (aka prefix) as prop names must
 	// be valid UTF-8 and the byte sequence "\xff\xff\xff\xff" is not valid.
 	uint32_t prop_key = prop != iter->prop_end ? prop->_internal_key : UINT32_MAX;
 	uint32_t over_key = over != iter->over_end ? over->_internal_key : UINT32_MAX;

--- a/ufbx.h
+++ b/ufbx.h
@@ -2673,7 +2673,7 @@ UFBX_ENUM_TYPE(ufbx_texture_type, UFBX_TEXTURE_TYPE, UFBX_TEXTURE_SHADER);
 
 // Blend modes to combine layered textures with, compatible with common blend
 // mode definitions in many art programs. Simpler blend modes have equations
-// specified below where `src` is the layer to compososite over `dst`.
+// specified below where `src` is the layer to composite over `dst`.
 // See eg. https://www.w3.org/TR/2013/WD-compositing-1-20131010/#blendingseparable
 typedef enum ufbx_blend_mode UFBX_ENUM_REPR {
 	UFBX_BLEND_TRANSLUCENT,   // < `src` effects result alpha


### PR DESCRIPTION
The fast path of `ufbx_evaluate_transform_flags()` (`ufbxi_get_rotation()`) did not account for mirroring. This PR fixes it and adds a bunch of tests that various transform evaluation methods work consistently.