### PR TITLE
Limit CMake 32-bit ARM architecture SDK version

### DIFF
--- a/misc/cmake/CMakePresets.json
+++ b/misc/cmake/CMakePresets.json
@@ -13,6 +13,9 @@
       "architecture": {
         "value": "arm",
         "strategy": "set"
+      },
+      "cacheVariables": {
+        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.22621.0"
       }
     },
     {


### PR DESCRIPTION
Looks like SDK version 10.0.26100.0 dropped support for ARM..