### PR TITLE
ufbx_math: fix NEON detection

### DIFF
--- a/extra/ufbx_math.c
+++ b/extra/ufbx_math.c
@@ -28,7 +28,7 @@
 		#define UFBXM_HAS_SSE
 		#include <xmmintrin.h>
 		#include <emmintrin.h>
-	#elif !defined(UFBX_NO_NEON) && (defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))) && ((defined(__GNUC__) || defined(__clang__)) && defined(__aarch64__)) || defined(UFBX_USE_NEON)
+	#elif !defined(UFBX_NO_NEON) && (defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))) || ((defined(__GNUC__) || defined(__clang__)) && defined(__aarch64__)) || defined(UFBX_USE_NEON)
 		#define UFBXM_HAS_NEON
 		#include <arm_neon.h>
 	#elif (defined(__clang__) && defined(__wasm__))


### PR DESCRIPTION
The clause was "if (msvc) and (gcc or clang)", which just never passes.