### PR TITLE
Thread pool documentation, minor interface changes

### DIFF
--- a/extra/ufbx_os.h
+++ b/extra/ufbx_os.h
@@ -1073,7 +1073,7 @@ static bool ufbxos_ufbx_thread_pool_init(void *user, ufbx_thread_pool_context ct
 	return true;
 }
 
-static bool ufbxos_ufbx_thread_pool_run(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
+static void ufbxos_ufbx_thread_pool_run(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
 {
 	ufbx_os_thread_pool *pool = (ufbx_os_thread_pool*)user;
 	ufbxos_pool_ctx *up = (ufbxos_pool_ctx*)ufbx_thread_pool_get_user_ptr(ctx);
@@ -1082,11 +1082,9 @@ static bool ufbxos_ufbx_thread_pool_run(void *user, ufbx_thread_pool_context ctx
 	ug->start_index = start_index;
 	ug->ctx = ctx;
 	ug->task_id = ufbx_os_thread_pool_run(pool, &ufbxos_ufbx_task, ug, count);
-
-	return true;
 }
 
-static bool ufbxos_ufbx_thread_pool_wait(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
+static void ufbxos_ufbx_thread_pool_wait(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
 {
 	(void)max_index;
 	ufbx_os_thread_pool *pool = (ufbx_os_thread_pool*)user;
@@ -1094,8 +1092,6 @@ static bool ufbxos_ufbx_thread_pool_wait(void *user, ufbx_thread_pool_context ct
 	ufbxos_pool_group *ug = &up->groups[group].group;
 
 	ufbx_os_thread_pool_wait(pool, ug->task_id);
-
-	return true;
 }
 
 static void ufbxos_ufbx_thread_pool_free(void *user, ufbx_thread_pool_context ctx)

--- a/test/test_api.h
+++ b/test/test_api.h
@@ -183,7 +183,7 @@ static bool ufbxt_single_thread_pool_init_fn(void *user, ufbx_thread_pool_contex
 	return true;
 }
 
-static bool ufbxt_single_thread_pool_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
+static void ufbxt_single_thread_pool_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
 {
 	ufbxt_single_thread_pool *pool = (ufbxt_single_thread_pool*)user;
 	ufbxt_assert(pool->initialized);
@@ -193,11 +193,9 @@ static bool ufbxt_single_thread_pool_run_fn(void *user, ufbx_thread_pool_context
 	for (uint32_t i = 0; i < count; i++) {
 		ufbx_thread_pool_run_task(ctx, start_index + i);
 	}
-
-	return true;
 }
 
-static bool ufbxt_single_thread_pool_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
+static void ufbxt_single_thread_pool_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
 {
 	ufbxt_single_thread_pool *pool = (ufbxt_single_thread_pool*)user;
 	ufbxt_assert(pool->initialized);
@@ -209,8 +207,6 @@ static bool ufbxt_single_thread_pool_wait_fn(void *user, ufbx_thread_pool_contex
 	}
 
 	pool->wait_index = max_index;
-
-	return true;
 }
 
 static void ufbxt_single_thread_pool_free_fn(void *user, ufbx_thread_pool_context ctx)

--- a/test/test_api.h
+++ b/test/test_api.h
@@ -188,7 +188,7 @@ static void ufbxt_single_thread_pool_run_fn(void *user, ufbx_thread_pool_context
 	ufbxt_single_thread_pool *pool = (ufbxt_single_thread_pool*)user;
 	ufbxt_assert(pool->initialized);
 	pool->dispatches++;
-	if (!pool->immediate) return true;
+	if (!pool->immediate) return;
 
 	for (uint32_t i = 0; i < count; i++) {
 		ufbx_thread_pool_run_task(ctx, start_index + i);

--- a/test/test_parse.h
+++ b/test/test_parse.h
@@ -1751,16 +1751,14 @@ UFBXT_FILE_TEST(synthetic_integer_holes)
 #endif
 
 #if UFBXT_IMPL
-static bool ufbxt_immediate_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
+static void ufbxt_immediate_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count)
 {
 	for (uint32_t i = 0; i < count; i++) {
 		ufbx_thread_pool_run_task(ctx, start_index + i);
 	}
-	return true;
 }
-static bool ufbxt_immediate_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
+static void ufbxt_immediate_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index)
 {
-	return true;
 }
 static ufbx_load_opts ufbxt_immediate_thread_opts()
 {

--- a/ufbx.c
+++ b/ufbx.c
@@ -830,7 +830,7 @@ ufbx_static_assert(sizeof_f64, sizeof(double) == 8);
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 15, 1)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 16, 0)
 ufbx_abi_data_def const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);

--- a/ufbx.h
+++ b/ufbx.h
@@ -4185,7 +4185,7 @@ UFBX_ENUM_TYPE(ufbx_error_type, UFBX_ERROR_TYPE, UFBX_ERROR_DUPLICATE_OVERRIDE);
 // HINT: You can use `ufbx_format_error()` for formatting the error
 typedef struct ufbx_error {
 
-	// Type of the error, or `UFBX_ERROR_NONE` if succesful.
+	// Type of the error, or `UFBX_ERROR_NONE` if successful.
 	ufbx_error_type type;
 
 	// Description of the error type.
@@ -5259,7 +5259,7 @@ ufbx_abi ufbx_string ufbx_find_string(const ufbx_props *props, const char *name,
 ufbx_abi ufbx_blob ufbx_find_blob_len(const ufbx_props *props, const char *name, size_t name_len, ufbx_blob def);
 ufbx_abi ufbx_blob ufbx_find_blob(const ufbx_props *props, const char *name, ufbx_blob def);
 
-// Find property in `props` with concatendated `parts[num_parts]`.
+// Find property in `props` with concatenated `parts[num_parts]`.
 ufbx_abi ufbx_prop *ufbx_find_prop_concat(const ufbx_props *props, const ufbx_string *parts, size_t num_parts);
 
 // Get an element connected to a property.

--- a/ufbx.h
+++ b/ufbx.h
@@ -4085,7 +4085,8 @@ typedef struct ufbx_open_memory_opts {
 	uint32_t _end_zero;
 } ufbx_open_memory_opts;
 
-// Detailed error stack frame
+// Detailed error stack frame.
+// NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
 typedef struct ufbx_error_frame {
 	uint32_t source_line;
 	ufbx_string function;
@@ -4183,30 +4184,48 @@ UFBX_ENUM_TYPE(ufbx_error_type, UFBX_ERROR_TYPE, UFBX_ERROR_DUPLICATE_OVERRIDE);
 // Error description with detailed stack trace
 // HINT: You can use `ufbx_format_error()` for formatting the error
 typedef struct ufbx_error {
+
+	// Type of the error, or `UFBX_ERROR_NONE` if succesful.
 	ufbx_error_type type;
+
+	// Description of the error type.
 	ufbx_string description;
+
+	// Internal error stack.
+	// NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
 	uint32_t stack_size;
 	ufbx_error_frame stack[UFBX_ERROR_STACK_MAX_DEPTH];
+
+	// Additional error information, such as missing file filename.
+	// `info` is a NULL-terminated UTF-8 string containing `info_length` bytes, excluding the trailing `'\0'`.
 	size_t info_length;
 	char info[UFBX_ERROR_INFO_LENGTH];
+
 } ufbx_error;
 
 // -- Progress callbacks
 
+// Loading progress information.
 typedef struct ufbx_progress {
 	uint64_t bytes_read;
 	uint64_t bytes_total;
 } ufbx_progress;
 
+// Progress result returned from `ufbx_progress_fn()` callback.
+// Determines whether ufbx should continue or abort the loading.
 typedef enum ufbx_progress_result UFBX_ENUM_REPR {
+
+	// Continue loading the file.
 	UFBX_PROGRESS_CONTINUE = 0x100,
+
+	// Cancel loading and fail with `UFBX_ERROR_CANCELLED`.
 	UFBX_PROGRESS_CANCEL = 0x200,
 
 	UFBX_ENUM_FORCE_WIDTH(UFBX_PROGRESS_RESULT)
 } ufbx_progress_result;
 
-// Called periodically with the current progress
-// Return `false` to cancel further processing
+// Called periodically with the current progress.
+// Return `UFBX_PROGRESS_CANCEL` to cancel further processing.
 typedef ufbx_progress_result ufbx_progress_fn(void *user, const ufbx_progress *progress);
 
 typedef struct ufbx_progress_cb {

--- a/ufbx.h
+++ b/ufbx.h
@@ -267,7 +267,7 @@ struct ufbx_converter { };
 // `ufbx_source_version` contains the version of the corresponding source file.
 // HINT: The version can be compared numerically to the result of `ufbx_pack_version()`,
 // for example `#if UFBX_VERSION >= ufbx_pack_version(0, 12, 0)`.
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 15, 1)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 16, 0)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types


### PR DESCRIPTION
Don't allow thread pool `run_fn()` and `wait_fn()` to fail, since failure handling code waits on threads, and waiting on partially succeeded tasks is not really well defined.