### PR TITLE
Add support for OpenPBR materials

### DIFF
--- a/data/max_openpbr_material_7700_ascii.fbx
+++ b/data/max_openpbr_material_7700_ascii.fbx
@@ -1,0 +1,1432 @@
+; FBX 7.7.0 project file
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1004
+	FBXVersion: 7700
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2025
+		Month: 3
+		Day: 26
+		Hour: 22
+		Minute: 46
+		Second: 6
+		Millisecond: 706
+	}
+	Creator: "FBX SDK/FBX Plugins version 2020.3.5"
+	OtherFlags:  {
+		TCDefinition: 127
+	}
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\max_openpbr_material_7700_ascii.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "D:\Dev\clean\ufbx\data\max_openpbr_material_7700_ascii.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "Original|ApplicationName", "KString", "", "", "3ds Max"
+			P: "Original|ApplicationVersion", "KString", "", "", "2025"
+			P: "Original|DateTime_GMT", "DateTime", "", "", "26/03/2025 20:46:06.705"
+			P: "Original|FileName", "KString", "", "", "D:\Dev\clean\ufbx\data\max_openpbr_material_7700_ascii.fbx"
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", "Autodesk"
+			P: "LastSaved|ApplicationName", "KString", "", "", "3ds Max"
+			P: "LastSaved|ApplicationVersion", "KString", "", "", "2025"
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", "26/03/2025 20:46:06.705"
+			P: "Original|ApplicationActiveProject", "KString", "", "", "C:\Users\Datacube\Documents\3ds Max 2025"
+			P: "Original|ApplicationNativeFile", "KString", "", "", "C:\Users\Datacube\Documents\3ds Max 2025\scenes\openpbr.max"
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",2
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",2.54
+		P: "OriginalUnitScaleFactor", "double", "Number", "",2.54
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",6
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",0
+		P: "TimeSpanStop", "KTime", "Time", "",153953860000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 1544263349984, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", ""
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 32
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "Model" {
+		Count: 1
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "Material" {
+		Count: 1
+		PropertyTemplate: "FbxSurfaceMaterial" {
+			Properties70:  {
+				P: "ShadingModel", "KString", "", "", "Unknown"
+				P: "MultiLayer", "bool", "", "",0
+			}
+		}
+	}
+	ObjectType: "Texture" {
+		Count: 26
+		PropertyTemplate: "FbxFileTexture" {
+			Properties70:  {
+				P: "TextureTypeUse", "enum", "", "",0
+				P: "Texture alpha", "Number", "", "A",1
+				P: "CurrentMappingType", "enum", "", "",0
+				P: "WrapModeU", "enum", "", "",0
+				P: "WrapModeV", "enum", "", "",0
+				P: "UVSwap", "bool", "", "",0
+				P: "PremultiplyAlpha", "bool", "", "",1
+				P: "Translation", "Vector", "", "A",0,0,0
+				P: "Rotation", "Vector", "", "A",0,0,0
+				P: "Scaling", "Vector", "", "A",1,1,1
+				P: "TextureRotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TextureScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "CurrentTextureBlendMode", "enum", "", "",1
+				P: "UVSet", "KString", "", "", "default"
+				P: "UseMaterial", "bool", "", "",0
+				P: "UseMipMap", "bool", "", "",0
+			}
+		}
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	Geometry: 1544267459712, "Geometry::", "Mesh" {
+		Properties70:  {
+			P: "Color", "ColorRGB", "Color", "",0.298039215686275,0.552941176470588,0.670588235294118
+		}
+		Vertices: *24 {
+			a: -10.0000047683716,-10.0000047683716,0,10.0000047683716,-10.0000047683716,0,-10.0000047683716,10.0000047683716,0,10.0000047683716,10.0000047683716,0,-10.0000047683716,-10.0000047683716,20.0000095367432,10.0000047683716,-10.0000047683716,20.0000095367432,-10.0000047683716,10.0000047683716,20.0000095367432,10.0000047683716,10.0000047683716,20.0000095367432
+		} 
+		PolygonVertexIndex: *24 {
+			a: 0,2,3,-2,4,5,7,-7,0,1,5,-5,1,3,7,-6,3,2,6,-8,2,0,4,-7
+		} 
+		Edges: *12 {
+			a: 0,1,2,3,4,5,6,7,9,11,13,17
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: ""
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "Direct"
+			Normals: *72 {
+				a: 0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,1,0,0,1,0,0,1,0,0,1,0,0,0,1,0,0,1,0,0,1,0,0,1,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0
+			} 
+			NormalsW: *24 {
+				a: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+			} 
+		}
+		LayerElementUV: 0 {
+			Version: 101
+			Name: "UVChannel_1"
+			MappingInformationType: "ByPolygonVertex"
+			ReferenceInformationType: "IndexToDirect"
+			UV: *48 {
+				a: 1,0,0,0,1,1,0,1,0,0,1,0,0,1,1,1,0,0,1,0,0,1,1,1,0,0,1,0,0,1,1,1,0,0,1,0,0,1,1,1,0,0,1,0,0,1,1,1
+			} 
+			UVIndex: *24 {
+				a: 0,2,3,1,4,5,7,6,8,9,11,10,12,13,15,14,16,17,19,18,20,21,23,22
+			} 
+		}
+		LayerElementMaterial: 0 {
+			Version: 101
+			Name: ""
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "IndexToDirect"
+			Materials: *1 {
+				a: 0
+			} 
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementMaterial"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUV"
+				TypedIndex: 0
+			}
+		}
+	}
+	Model: 1500361746784, "Model::Box001", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "PreRotation", "Vector3D", "Vector", "",-90,-0,0
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "MaxHandle", "int", "Integer", "UH",3
+		}
+		Shading: T
+		Culling: "CullingOff"
+	}
+	Material: 1547108550704, "Material::OpenPBR", "" {
+		Version: 102
+		ShadingModel: "unknown"
+		MultiLayer: 0
+		Properties70:  {
+			P: "ShadingModel", "KString", "", "", "unknown"
+			P: "AmbientColor", "ColorRGB", "Color", "",0.000199999994947575,0.000299999985145405,0.00039999998989515
+			P: "DiffuseColor", "ColorRGB", "Color", "",0.000199999994947575,0.000299999985145405,0.00039999998989515
+			P: "SpecularColor", "ColorRGB", "Color", "",0.00676808645948768,0.00752014433965087,0.00827221106737852
+			P: "SpecularFactor", "double", "Number", "",2.23600006103516
+			P: "ShininessExponent", "double", "Number", "",388.023529052734
+			P: "TransparencyFactor", "double", "Number", "",0.0172799993306398
+			P: "EmissiveColor", "ColorRGB", "Color", "",3.87044215202332,3.93955755233765,4.00867223739624
+			P: "EmissiveFactor", "double", "Number", "",1
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-246079949
+			P: "3dsMax|ClassIDb", "int", "Integer", "",939201335
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3072
+			P: "3dsMax|Parameters", "Compound", "", ""
+			P: "3dsMax|Parameters|notes", "KString", "", "A", ""
+			P: "3dsMax|Parameters|base_weight", "Float", "", "A",0.01
+			P: "3dsMax|Parameters|base_color", "ColorAndAlpha", "", "A",0.0199999995529652,0.0299999993294477,0.0399999991059303,0.0500000007450581
+			P: "3dsMax|Parameters|base_metalness", "Float", "", "A",0.06
+			P: "3dsMax|Parameters|base_diffuse_roughness", "Float", "", "A",0.07
+			P: "3dsMax|Parameters|specular_weight", "Float", "", "A",0.08
+			P: "3dsMax|Parameters|specular_color", "ColorAndAlpha", "", "A",0.0900000035762787,0.100000001490116,0.109999999403954,0.119999997317791
+			P: "3dsMax|Parameters|specular_roughness", "Float", "", "A",0.14
+			P: "3dsMax|Parameters|specular_roughness_anisotropy", "Float", "", "A",0.15
+			P: "3dsMax|Parameters|specular_ior", "Float", "", "A",1.3
+			P: "3dsMax|Parameters|transmission_weight", "Float", "", "A",0.16
+			P: "3dsMax|Parameters|transmission_color", "ColorAndAlpha", "", "A",0.170000001788139,0.180000007152557,0.189999997615814,0.200000002980232
+			P: "3dsMax|Parameters|transmission_depth", "Float", "", "A",0.21
+			P: "3dsMax|Parameters|transmission_scatter", "ColorAndAlpha", "", "A",0.219999998807907,0.230000004172325,0.239999994635582,0.25
+			P: "3dsMax|Parameters|transmission_scatter_anisotropy", "Float", "", "A",0.26
+			P: "3dsMax|Parameters|transmission_dispersion_scale", "Float", "", "A",0.27
+			P: "3dsMax|Parameters|transmission_dispersion_abbe_number", "Float", "", "A",0.28
+			P: "3dsMax|Parameters|subsurface_weight", "Float", "", "A",0.29
+			P: "3dsMax|Parameters|subsurface_color", "ColorAndAlpha", "", "A",0.300000011920929,0.310000002384186,0.319999992847443,0.330000013113022
+			P: "3dsMax|Parameters|subsurface_radius", "Float", "", "A",0.39
+			P: "3dsMax|Parameters|subsurface_radius_scale", "ColorAndAlpha", "", "A",0.349999994039536,0.360000014305115,0.370000004768372,0.379999995231628
+			P: "3dsMax|Parameters|subsurface_scatter_anisotropy", "Float", "", "A",0.34
+			P: "3dsMax|Parameters|coat_weight", "Float", "", "A",0.4
+			P: "3dsMax|Parameters|coat_color", "ColorAndAlpha", "", "A",0.409999996423721,0.419999986886978,0.430000007152557,0.439999997615814
+			P: "3dsMax|Parameters|coat_roughness", "Float", "", "A",0.46
+			P: "3dsMax|Parameters|coat_roughness_anisotropy", "Float", "", "A",0.47
+			P: "3dsMax|Parameters|coat_ior", "Float", "", "A",4.5
+			P: "3dsMax|Parameters|coat_darkening", "Float", "", "A",0.48
+			P: "3dsMax|Parameters|fuzz_weight", "Float", "", "A",0.49
+			P: "3dsMax|Parameters|fuzz_color", "ColorAndAlpha", "", "A",0.5,0.509999990463257,0.519999980926514,0.529999971389771
+			P: "3dsMax|Parameters|fuzz_roughness", "Float", "", "A",0.54
+			P: "3dsMax|Parameters|emission_weight", "Float", "", "A",0.55
+			P: "3dsMax|Parameters|emission_color", "ColorAndAlpha", "", "A",0.560000002384186,0.569999992847443,0.579999983310699,0.589999973773956
+			P: "3dsMax|Parameters|emission_luminance", "Float", "", "A",6000
+			P: "3dsMax|Parameters|thin_film_weight", "Float", "", "A",0.61
+			P: "3dsMax|Parameters|thin_film_thickness", "Float", "", "A",0.62
+			P: "3dsMax|Parameters|thin_film_ior", "Float", "", "A",6.3
+			P: "3dsMax|Parameters|geometry_thin_walled", "Bool", "", "A",1
+			P: "3dsMax|Parameters|base_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|base_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|base_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|base_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|base_metalness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|base_metalness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|base_diffuse_roughness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|base_diffuse_roughness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|specular_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|specular_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|specular_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|specular_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|specular_roughness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|specular_roughness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|specular_roughness_anisotropy_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|specular_roughness_anisotropy_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|specular_ior_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|specular_ior_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_depth_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_depth_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_scatter_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_scatter_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_scatter_anisotropy_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_scatter_anisotropy_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_dispersion_scale_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_dispersion_scale_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|transmission_dispersion_abbe_number_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|transmission_dispersion_abbe_number_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|subsurface_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|subsurface_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|subsurface_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|subsurface_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|subsurface_radius_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|subsurface_radius_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|subsurface_radius_scale_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|subsurface_radius_scale_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|subsurface_scatter_anisotropy_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|subsurface_scatter_anisotropy_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_roughness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_roughness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_roughness_anisotropy_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_roughness_anisotropy_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_ior_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_ior_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_darkening_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_darkening_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|fuzz_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|fuzz_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|fuzz_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|fuzz_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|fuzz_roughness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|fuzz_roughness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|emission_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|emission_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|emission_color_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|emission_color_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|emission_luminance_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|emission_luminance_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|thin_film_weight_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|thin_film_weight_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|thin_film_thickness_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|thin_film_thickness_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|thin_film_ior_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|thin_film_ior_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|bump_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|bump_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|coat_bump_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|coat_bump_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|displacement_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|displacement_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|geometry_normal_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|geometry_normal_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|geometry_tangent_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|geometry_tangent_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|geometry_coat_normal_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|geometry_coat_normal_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|geometry_coat_tangent_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|geometry_coat_tangent_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|geometry_opacity_map", "Reference", "", "A"
+			P: "3dsMax|Parameters|geometry_opacity_map_on", "Bool", "", "A",1
+			P: "3dsMax|Parameters|bump_map_amt", "Float", "", "A",0.64
+			P: "3dsMax|Parameters|coat_bump_map_amt", "Float", "", "A",0.65
+			P: "3dsMax|Parameters|displacement_map_amt", "Float", "", "A",0.66
+			P: "caustics", "Bool", "", "AU",0
+			P: "internal_reflections", "Bool", "", "AU",1
+			P: "exit_to_background", "Bool", "", "AU",0
+			P: "indirect_diffuse", "Number", "", "AU",0.670000016689301,0.670000016689301,0.670000016689301
+			P: "indirect_diffuse_map", "Reference", "", "AU"
+			P: "indirect_specular", "Number", "", "AU",0.680000007152557,0.680000007152557,0.680000007152557
+			P: "indirect_specular_map", "Reference", "", "AU"
+			P: "dielectric_priority", "Integer", "", "AU",0,0,100
+		}
+	}
+	Texture: 1544267450112, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267458272, "Texture::Map #1", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #1"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_diffuse.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267475552, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267464512, "Texture::Map #8", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #8"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_metallic.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267445312, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267471232, "Texture::Map #2", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #2"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_specular.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267467392, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267467872, "Texture::Map #3", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #3"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_roughness.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267450592, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267473152, "Texture::Map #4", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #4"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_transparency.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267460672, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267451072, "Texture::Map #5", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #5"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_reflection.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267465472, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267451552, "Texture::Map #6", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #6"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_ambient.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267455392, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267453472, "Texture::Map #7", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #7"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_weight.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267461632, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267474112, "Texture::Map #12", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #12"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_weight.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267468352, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267445792, "Texture::Map #9", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #9"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_emissive.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267453952, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267456352, "Texture::Map #13", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #13"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\tiny_clouds.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267468832, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267485152, "Texture::Map #10", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #10"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_normal.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267492832, "Texture::", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",-1989217540
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1153266751
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|parameters", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "MULTIOUTPUT_TO_OSLMap"
+			P: "3dsMax|parameters|sourceMap", "Reference", "", "A"
+			P: "3dsMax|parameters|outputChannelIndex", "Integer", "", "A",0
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	Texture: 1544267498592, "Texture::Map #11", "" {
+		Type: "TextureVideoClip"
+		Version: 202
+		TextureName: "Texture::Map #11"
+		Properties70:  {
+			P: "3dsMax", "Compound", "", ""
+			P: "3dsMax|ClassIDa", "int", "Integer", "",2140830621
+			P: "3dsMax|ClassIDb", "int", "Integer", "",1875767309
+			P: "3dsMax|SuperClassID", "int", "Integer", "",3088
+			P: "3dsMax|params", "Compound", "", ""
+			P: "3dsMax|MaxTexture", "KString", "", "", "OSLMap"
+			P: "3dsMax|params|OSLPath", "KString", "", "A", "F:\Programs\Autodesk\3ds Max 2025\OSL\OSLBitmap2.osl"
+			P: "3dsMax|params|OSLCode", "KString", "", "A", "// Lookup a bitmap bitmap with OSL&cr;&lf;// OSLBitmap.osl, by Zap Andersson&cr;&lf;// Modified: 2022-12-07&cr;&lf;// Copyright 2022 Autodesk Inc, All rights reserved. This file is licensed under Apache 2.0 license&cr;&lf;//    https://github.com/ADN-DevTech/3dsMax-OSL-Shaders/blob/license/LICENSE.txt&cr;&lf;&cr;&lf;shader OSLBitmap3&cr;&lf;[[ string help  = &quot;Look up a bitmap from passed in UV coordinates<br/>(through OpenImageIO)&quot;,&cr;&lf;   string label = &quot;Bitmap Lookup&quot;,&cr;&lf;   string version = &quot;3.0&quot; ]]&cr;&lf;(  &cr;&lf;  point  Pos   = point(u,v,0) &cr;&lf;  	[[  string label= &quot;UV Coordinate&quot;, &cr;&lf;  		string help = &quot;The 2D coordinate at which the texture is looked up.&quot; ]],&cr;&lf;  float  Scale  = 1.0&cr;&lf;  	[[  string help = &quot;A linear scale factor. For more complex UV manipulation, connect the UVWTransform.&quot; ]], &cr;&lf;  &cr;&lf;  string Filename = &quot;&quot; &cr;&lf;  	[[ string widget=&quot;filename&quot;, &cr;&lf;  	   string label=&quot;File name&quot;,&cr;&lf;  	   string help=&quot;The name of the texture to look up&quot; ]], &cr;&lf;  string Filename_ColorSpace = &quot;auto&quot; [[ string widget=&quot;popup&quot;,		   &cr;&lf;	   string options=&quot;auto|Raw|sRGB|ACEScg|scene-linear Rec.709-sRGB&quot;,&cr;&lf;	   int editable=1, int connectable = 0, int colorSpace=1 ]],&cr;&lf;  string Filename_UDIMList = &quot;&quot; &cr;&lf;  	[[ string widget = &quot;null&quot;,&cr;&lf;  	   string label=&quot;Viewport UDIM List&quot;,&cr;&lf;  	   string help=&quot;The list of UDIM items to load into the viewport. If empty, will be deduced from the file system automatically. &quot; ]], &cr;&lf;  string LoadUDIM = &quot;Load UDIM...&quot; &cr;&lf;  	[[ string widget=&quot;max:actionButton&quot;, &cr;&lf;  	   string actionID=&quot;loadUDIM(\&quot;Filename\&quot;)&quot;,&cr;&lf;  	   string help=&quot;Select a set of files to load as an UDIM.&quot;,&cr;&lf;  	   int    connectable = 0 ]],   	   &cr;&lf;  int    UDIM   = 0&cr;&lf;  	[[ string widget=&quot;checkBox&quot;, string label=&quot;UDIM-compatible lookup&quot;,&cr;&lf;  	   int connectable = 0,&cr;&lf;  	   string help  =&quot;Modifies the UV coordinate so that UDIM's are looked up similar to the max MultiTile map&quot; ]],  	   &cr;&lf;		   		   &cr;&lf;  string WrapMode = &quot;periodic&quot;&cr;&lf;  	[[ string widget=&quot;popup&quot;, string options = &quot;default|black|clamp|periodic|mirror&quot;,&cr;&lf;  	   string label=&quot;Wrap Mode&quot;,&cr;&lf;  	   string help=&quot;How the texture wraps: (black, clamp, periodic or mirror).&quot; ]],&cr;&lf; &cr;&lf;  float  ManualGamma = 1.0 &cr;&lf;  	[[ string label=&quot;Manual Gamma&quot; ]],&cr;&lf;    &cr;&lf;  output color Col = 0     [[ string label=&quot;Col (RGB)&quot; ]],&cr;&lf;  output float R = 0,&cr;&lf;  output float G = 0,&cr;&lf;  output float B = 0,&cr;&lf;  output float A = 1,&cr;&lf;  output float Luminance = 0,&cr;&lf;  output float Average = 0&cr;&lf;)&cr;&lf;{&cr;&lf;	// Skip empty files&cr;&lf;	if (Filename == &quot;&quot;)&cr;&lf;		return;&cr;&lf;	&cr;&lf;	point p = Pos  / Scale;&cr;&lf;&cr;&lf;	// Default lookup, just use u and inverted v...&cr;&lf;	float ulookup = p[0];&cr;&lf;	float vlookup = 1.0 - p[1];&cr;&lf;	&cr;&lf;	// But for UDIM compatibility and max's idea that 0,0 is in &cr;&lf;	// lower left corner, we need this juggling of v....&cr;&lf;	if (UDIM)&cr;&lf;	{&cr;&lf;		float vfloor  = floor(p[1]);&cr;&lf;		float vfrac   = p[1] - vfloor;&cr;&lf;		vlookup = vfloor + (1.0 - vfrac);&cr;&lf;	}&cr;&lf;	&cr;&lf;	Col  = texture(Filename, ulookup, vlookup, &quot;wrap&quot;, WrapMode, &quot;alpha&quot;, A, &quot;colorspace&quot;, Filename_ColorSpace);&cr;&lf;	&cr;&lf;	int channels;&cr;&lf;	gettextureinfo(Filename, &quot;channels&quot;, channels);&cr;&lf;	if (channels < 4) // No alpha? Set it to opaque&cr;&lf;	{&cr;&lf;		A = 1.0;&cr;&lf;&cr;&lf;		if (WrapMode == &quot;black&quot;) // 2018-04-25: Allow Decals&cr;&lf;		{&cr;&lf;			if (p[0] < 0.0 || p[0] > 1.0 ||&cr;&lf;			    p[1] < 0.0 || p[1] > 1.0)&cr;&lf;			    A = 0.0;&cr;&lf;		}&cr;&lf;	}&cr;&lf;	&cr;&lf;&cr;&lf;	if (ManualGamma != 1.0)&cr;&lf;		Col = pow(Col, ManualGamma);&cr;&lf;	&cr;&lf;	R = Col[0];&cr;&lf;	G = Col[1];&cr;&lf;	B = Col[2];&cr;&lf;	Luminance = luminance(Col);&cr;&lf;	Average   = (R + G + B) / 3.0;&cr;&lf;}"
+             
+			P: "3dsMax|params|OSLAutoUpdate", "Bool", "", "A",1
+			P: "3dsMax|params|OSLShaderName", "KString", "", "A", "OSLBitmap3"
+			P: "3dsMax|params|OSLPresetName", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3", "Compound", "", ""
+			P: "3dsMax|OSLBitmap3|Scale", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Filename", "KString", "", "A", "D:\Dev\clean\ufbx\data\textures\checkerboard_vector_displacement.png"
+			P: "3dsMax|OSLBitmap3|Filename_ColorSpace", "KString", "", "A", "auto"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList", "KString", "", "A", ""
+			P: "3dsMax|OSLBitmap3|LoadUDIM", "KString", "", "A", "Load UDIM..."
+			P: "3dsMax|OSLBitmap3|UDIM", "Integer", "", "A",0
+			P: "3dsMax|OSLBitmap3|WrapMode", "KString", "", "A", "periodic"
+			P: "3dsMax|OSLBitmap3|ManualGamma", "Float", "", "A",1
+			P: "3dsMax|OSLBitmap3|Pos_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Scale_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|Filename_UDIMList_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|WrapMode_map", "Reference", "", "A"
+			P: "3dsMax|OSLBitmap3|ManualGamma_map", "Reference", "", "A"
+		}
+		Media: ""
+		FileName: ""
+		RelativeFilename: ""
+		ModelUVTranslation: 0,0
+		ModelUVScaling: 1,1
+		Texture_Alpha_Source: "None"
+		Cropping: 0,0,0,0
+	}
+	AnimationStack: 1498772881824, "AnimStack::Take 001", "" {
+		Properties70:  {
+			P: "LocalStop", "KTime", "Time", "",153953860000
+			P: "ReferenceStop", "KTime", "Time", "",153953860000
+		}
+	}
+	AnimationLayer: 1541397197392, "AnimLayer::BaseLayer", "" {
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::Box001, Model::RootNode
+	C: "OO",1500361746784,0
+	
+	;AnimLayer::BaseLayer, AnimStack::Take 001
+	C: "OO",1541397197392,1498772881824
+	
+	;Geometry::, Model::Box001
+	C: "OO",1544267459712,1500361746784
+	
+	;Material::OpenPBR, Model::Box001
+	C: "OO",1547108550704,1500361746784
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267450112,1547108550704, "3dsMax|Parameters|base_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267475552,1547108550704, "3dsMax|Parameters|base_metalness_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267445312,1547108550704, "3dsMax|Parameters|specular_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267467392,1547108550704, "3dsMax|Parameters|specular_roughness_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267450592,1547108550704, "3dsMax|Parameters|transmission_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267460672,1547108550704, "3dsMax|Parameters|transmission_scatter_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267465472,1547108550704, "3dsMax|Parameters|subsurface_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267455392,1547108550704, "3dsMax|Parameters|coat_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267461632,1547108550704, "3dsMax|Parameters|emission_weight_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267468352,1547108550704, "3dsMax|Parameters|emission_color_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267453952,1547108550704, "3dsMax|Parameters|emission_luminance_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267468832,1547108550704, "3dsMax|Parameters|bump_map"
+	
+	;Texture::, Material::OpenPBR
+	C: "OP",1544267492832,1547108550704, "3dsMax|Parameters|displacement_map"
+	
+	;Texture::Map #1, Texture::
+	C: "OP",1544267458272,1544267450112, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #8, Texture::
+	C: "OP",1544267464512,1544267475552, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #2, Texture::
+	C: "OP",1544267471232,1544267445312, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #3, Texture::
+	C: "OP",1544267467872,1544267467392, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #4, Texture::
+	C: "OP",1544267473152,1544267450592, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #5, Texture::
+	C: "OP",1544267451072,1544267460672, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #6, Texture::
+	C: "OP",1544267451552,1544267465472, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #7, Texture::
+	C: "OP",1544267453472,1544267455392, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #12, Texture::
+	C: "OP",1544267474112,1544267461632, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #9, Texture::
+	C: "OP",1544267445792,1544267468352, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #13, Texture::
+	C: "OP",1544267456352,1544267453952, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #10, Texture::
+	C: "OP",1544267485152,1544267468832, "3dsMax|parameters|sourceMap"
+	
+	;Texture::Map #11, Texture::
+	C: "OP",1544267498592,1544267492832, "3dsMax|parameters|sourceMap"
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: ""
+	Take: "Take 001" {
+		FileName: "Take_001.tak"
+		LocalTime: 0,153953860000
+		ReferenceTime: 0,153953860000
+	}
+}

--- a/test/check_material.h
+++ b/test/check_material.h
@@ -78,6 +78,7 @@ static const char *ufbxt_pbr_map_name(ufbx_material_pbr_map map)
 	case UFBX_MATERIAL_PBR_COAT_NORMAL: return "coat_normal";
 	case UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_COLOR: return "coat_affect_base_color";
 	case UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_ROUGHNESS: return "coat_affect_base_roughness";
+	case UFBX_MATERIAL_PBR_THIN_FILM_FACTOR: return "thin_film_factor";
 	case UFBX_MATERIAL_PBR_THIN_FILM_THICKNESS: return "thin_film_thickness";
 	case UFBX_MATERIAL_PBR_THIN_FILM_IOR: return "thin_film_ior";
 	case UFBX_MATERIAL_PBR_EMISSION_FACTOR: return "emission_factor";
@@ -150,6 +151,7 @@ static const char *ufbxt_shader_type_name(ufbx_shader_type map)
 	case UFBX_SHADER_3DS_MAX_PBR_METAL_ROUGH: return "3ds_max_pbr_metal_rough";
 	case UFBX_SHADER_3DS_MAX_PBR_SPEC_GLOSS: return "3ds_max_pbr_spec_gloss";
 	case UFBX_SHADER_GLTF_MATERIAL: return "gltf_material";
+	case UFBX_SHADER_OPENPBR_MATERIAL: return "openpbr_material";
 	case UFBX_SHADER_SHADERFX_GRAPH: return "shaderfx_graph";
 	case UFBX_SHADER_BLENDER_PHONG: return "blender_phong";
 	case UFBX_SHADER_WAVEFRONT_MTL: return "wavefront_mtl";
@@ -158,7 +160,7 @@ static const char *ufbxt_shader_type_name(ufbx_shader_type map)
 #endif
 	}
 
-	ufbxt_assert(0 && "Unhandled material feature name");
+	ufbxt_assert(0 && "Unhandled shader type");
 	return 0;
 }
 

--- a/test/test_material.h
+++ b/test/test_material.h
@@ -1066,7 +1066,7 @@ UFBXT_FILE_TEST(maya_arnold_properties)
 
 	// Computed
 	ufbxt_assert_close_real(err, material->pbr.transmission_roughness.value_real, 0.36f); // 11+25
-	ufbxt_assert(err, material->pbr.thin_film_factor.value_real == 1.0f);
+	ufbxt_assert(material->pbr.thin_film_factor.value_real == 1.0f);
 
 	ufbxt_assert(material->pbr.base_factor.value_components == 1);
 	ufbxt_assert(material->pbr.base_color.value_components == 3);
@@ -1204,7 +1204,7 @@ UFBXT_FILE_TEST(maya_osl_properties)
 
 	// Computed
 	ufbxt_assert_close_real(err, material->pbr.transmission_roughness.value_real, 0.36f); // 11+25
-	ufbxt_assert(err, material->pbr.thin_film_factor.value_real == 1.0f);
+	ufbxt_assert(material->pbr.thin_film_factor.value_real == 1.0f);
 
 	ufbxt_assert(material->features.thin_walled.enabled);
 	ufbxt_assert(material->features.thin_walled.is_explicit);

--- a/test/test_material.h
+++ b/test/test_material.h
@@ -610,6 +610,165 @@ UFBXT_FILE_TEST(maya_shaderfx_pbs_material)
 }
 #endif
 
+UFBXT_FILE_TEST(max_openpbr_material)
+#if UFBXT_IMPL
+{
+	ufbx_material *material = (ufbx_material*)ufbx_find_element(scene, UFBX_ELEMENT_MATERIAL, "OpenPBR");
+	ufbxt_assert(material);
+
+	ufbxt_assert(material->shader_type == UFBX_SHADER_OPENPBR_MATERIAL);
+
+	ufbxt_assert( 1 == (int)round(100.0f * material->pbr.base_factor.value_real));
+	ufbxt_assert( 2 == (int)round(100.0f * material->pbr.base_color.value_vec4.x));
+	ufbxt_assert( 3 == (int)round(100.0f * material->pbr.base_color.value_vec4.y));
+	ufbxt_assert( 4 == (int)round(100.0f * material->pbr.base_color.value_vec4.z));
+	ufbxt_assert( 5 == (int)round(100.0f * material->pbr.base_color.value_vec4.w));
+	ufbxt_assert( 6 == (int)round(100.0f * material->pbr.metalness.value_real));
+	ufbxt_assert( 7 == (int)round(100.0f * material->pbr.diffuse_roughness.value_real));
+	ufbxt_assert( 8 == (int)round(100.0f * material->pbr.specular_factor.value_real));
+	ufbxt_assert( 9 == (int)round(100.0f * material->pbr.specular_color.value_vec4.x));
+	ufbxt_assert(10 == (int)round(100.0f * material->pbr.specular_color.value_vec4.y));
+	ufbxt_assert(11 == (int)round(100.0f * material->pbr.specular_color.value_vec4.z));
+	ufbxt_assert(12 == (int)round(100.0f * material->pbr.specular_color.value_vec4.w));
+	// 13 specular_ior
+	ufbxt_assert(14 == (int)round(100.0f * material->pbr.roughness.value_real));
+	ufbxt_assert(15 == (int)round(100.0f * material->pbr.specular_anisotropy.value_real));
+	ufbxt_assert(16 == (int)round(100.0f * material->pbr.transmission_factor.value_real));
+	ufbxt_assert(17 == (int)round(100.0f * material->pbr.transmission_color.value_vec4.x));
+	ufbxt_assert(18 == (int)round(100.0f * material->pbr.transmission_color.value_vec4.y));
+	ufbxt_assert(19 == (int)round(100.0f * material->pbr.transmission_color.value_vec4.z));
+	ufbxt_assert(20 == (int)round(100.0f * material->pbr.transmission_color.value_vec4.w));
+	ufbxt_assert(21 == (int)round(100.0f * material->pbr.transmission_depth.value_real));
+	ufbxt_assert(22 == (int)round(100.0f * material->pbr.transmission_scatter.value_vec4.x));
+	ufbxt_assert(23 == (int)round(100.0f * material->pbr.transmission_scatter.value_vec4.y));
+	ufbxt_assert(24 == (int)round(100.0f * material->pbr.transmission_scatter.value_vec4.z));
+	ufbxt_assert(25 == (int)round(100.0f * material->pbr.transmission_scatter.value_vec4.w));
+	ufbxt_assert(26 == (int)round(100.0f * material->pbr.transmission_scatter_anisotropy.value_real));
+	ufbxt_assert(27 == (int)round(100.0f * material->pbr.transmission_dispersion.value_real));
+	// 28 Abbe number unsupported
+	ufbxt_assert(29 == (int)round(100.0f * material->pbr.subsurface_factor.value_real));
+	ufbxt_assert(30 == (int)round(100.0f * material->pbr.subsurface_color.value_vec4.x));
+	ufbxt_assert(31 == (int)round(100.0f * material->pbr.subsurface_color.value_vec4.y));
+	ufbxt_assert(32 == (int)round(100.0f * material->pbr.subsurface_color.value_vec4.z));
+	ufbxt_assert(33 == (int)round(100.0f * material->pbr.subsurface_color.value_vec4.w));
+	ufbxt_assert(34 == (int)round(100.0f * material->pbr.subsurface_anisotropy.value_real));
+	ufbxt_assert(35 == (int)round(100.0f * material->pbr.subsurface_radius.value_vec4.x));
+	ufbxt_assert(36 == (int)round(100.0f * material->pbr.subsurface_radius.value_vec4.y));
+	ufbxt_assert(37 == (int)round(100.0f * material->pbr.subsurface_radius.value_vec4.z));
+	ufbxt_assert(38 == (int)round(100.0f * material->pbr.subsurface_radius.value_vec4.w));
+	ufbxt_assert(39 == (int)round(100.0f * material->pbr.subsurface_scale.value_real));
+	ufbxt_assert(40 == (int)round(100.0f * material->pbr.coat_factor.value_real));
+	ufbxt_assert(41 == (int)round(100.0f * material->pbr.coat_color.value_vec4.x));
+	ufbxt_assert(42 == (int)round(100.0f * material->pbr.coat_color.value_vec4.y));
+	ufbxt_assert(43 == (int)round(100.0f * material->pbr.coat_color.value_vec4.z));
+	ufbxt_assert(44 == (int)round(100.0f * material->pbr.coat_color.value_vec4.w));
+	// 45 coat_ior
+	ufbxt_assert(46 == (int)round(100.0f * material->pbr.coat_roughness.value_real));
+	ufbxt_assert(47 == (int)round(100.0f * material->pbr.coat_anisotropy.value_real));
+	// 48 Coat roughness unsupported
+	ufbxt_assert(49 == (int)round(100.0f * material->pbr.sheen_factor.value_real));
+	ufbxt_assert(50 == (int)round(100.0f * material->pbr.sheen_color.value_vec4.x));
+	ufbxt_assert(51 == (int)round(100.0f * material->pbr.sheen_color.value_vec4.y));
+	ufbxt_assert(52 == (int)round(100.0f * material->pbr.sheen_color.value_vec4.z));
+	ufbxt_assert(53 == (int)round(100.0f * material->pbr.sheen_color.value_vec4.w));
+	ufbxt_assert(54 == (int)round(100.0f * material->pbr.sheen_roughness.value_real));
+	// 55 emission combined check below
+	ufbxt_assert(56 == (int)round(100.0f * material->pbr.emission_color.value_vec4.x));
+	ufbxt_assert(57 == (int)round(100.0f * material->pbr.emission_color.value_vec4.y));
+	ufbxt_assert(58 == (int)round(100.0f * material->pbr.emission_color.value_vec4.z));
+	ufbxt_assert(59 == (int)round(100.0f * material->pbr.emission_color.value_vec4.w));
+	// 60 luminance combined with emission_factor
+	ufbxt_assert(61 == (int)round(100.0f * material->pbr.thin_film_factor.value_real));
+	ufbxt_assert(62 == (int)round(100.0f * material->pbr.thin_film_thickness.value_real));
+	// 63 thin_film_ior
+	ufbxt_assert(64 == (int)round(100.0f * material->pbr.normal_map.value_real));
+	ufbxt_assert(65 == (int)round(100.0f * material->pbr.coat_normal.value_real));
+	ufbxt_assert(66 == (int)round(100.0f * material->pbr.displacement_map.value_real));
+	// 67 indirect_diffuse currently unparsed due to not having a prefix
+	// 68 indirecct_specular currently unparsed due to not having a prefix
+
+	ufbxt_assert(130 == (int)round(100.0f * material->pbr.specular_ior.value_real));
+	ufbxt_assert(450 == (int)round(100.0f * material->pbr.coat_ior.value_real));
+	ufbxt_assert(630 == (int)round(100.0f * material->pbr.thin_film_ior.value_real));
+
+	ufbxt_assert_close_real(err, material->pbr.emission_factor.value_real, 0.55f * 6000.0f);
+
+	ufbxt_check_material_texture(scene, material->pbr.base_color.texture, "checkerboard_diffuse.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.metalness.texture, "checkerboard_metallic.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.specular_color.texture, "checkerboard_specular.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.roughness.texture, "checkerboard_roughness.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.transmission_color.texture, "checkerboard_transparency.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.transmission_scatter.texture, "checkerboard_reflection.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.subsurface_color.texture, "checkerboard_ambient.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.coat_color.texture, "checkerboard_weight.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.emission_color.texture, "checkerboard_emissive.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.emission_factor.texture, "tiny_clouds.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.normal_map.texture, "checkerboard_normal.png", false);
+	ufbxt_check_material_texture(scene, material->pbr.displacement_map.texture, "checkerboard_vector_displacement.png", false);
+
+	ufbxt_assert(material->pbr.base_factor.texture_enabled);
+	ufbxt_assert(material->pbr.base_color.texture_enabled);
+	ufbxt_assert(material->pbr.specular_factor.texture_enabled);
+	ufbxt_assert(material->pbr.specular_color.texture_enabled);
+	ufbxt_assert(material->pbr.roughness.texture_enabled);
+	ufbxt_assert(material->pbr.metalness.texture_enabled);
+	ufbxt_assert(material->pbr.diffuse_roughness.texture_enabled);
+	ufbxt_assert(material->pbr.specular_anisotropy.texture_enabled);
+	ufbxt_assert(material->pbr.transmission_factor.texture_enabled);
+	ufbxt_assert(material->pbr.transmission_color.texture_enabled);
+	ufbxt_assert(material->pbr.specular_ior.texture_enabled);
+	ufbxt_assert(material->pbr.subsurface_factor.texture_enabled);
+	ufbxt_assert(material->pbr.subsurface_scale.texture_enabled);
+	ufbxt_assert(material->pbr.emission_factor.texture_enabled);
+	ufbxt_assert(material->pbr.emission_color.texture_enabled);
+	ufbxt_assert(material->pbr.coat_factor.texture_enabled);
+	ufbxt_assert(material->pbr.coat_color.texture_enabled);
+	ufbxt_assert(material->pbr.coat_roughness.texture_enabled);
+	ufbxt_assert(material->pbr.normal_map.texture_enabled);
+	ufbxt_assert(material->pbr.coat_normal.texture_enabled);
+	ufbxt_assert(material->pbr.displacement_map.texture_enabled);
+	ufbxt_assert(material->pbr.opacity.texture_enabled);
+
+	ufbxt_assert(material->pbr.base_factor.value_components == 1);
+	ufbxt_assert(material->pbr.base_color.value_components == 4);
+	ufbxt_assert(material->pbr.specular_factor.value_components == 1);
+	ufbxt_assert(material->pbr.specular_color.value_components == 4);
+	ufbxt_assert(material->pbr.roughness.value_components == 1);
+	ufbxt_assert(material->pbr.metalness.value_components == 1);
+	ufbxt_assert(material->pbr.diffuse_roughness.value_components == 1);
+	ufbxt_assert(material->pbr.specular_anisotropy.value_components == 1);
+	ufbxt_assert(material->pbr.transmission_factor.value_components == 1);
+	ufbxt_assert(material->pbr.transmission_color.value_components == 4);
+	ufbxt_assert(material->pbr.transmission_extra_roughness.value_components == 0);
+	ufbxt_assert(material->pbr.specular_ior.value_components == 1);
+	ufbxt_assert(material->pbr.subsurface_factor.value_components == 1);
+	ufbxt_assert(material->pbr.subsurface_color.value_components == 4);
+	ufbxt_assert(material->pbr.subsurface_radius.value_components == 4);
+	ufbxt_assert(material->pbr.subsurface_scale.value_components == 1);
+	ufbxt_assert(material->pbr.emission_factor.value_components == 1);
+	ufbxt_assert(material->pbr.emission_color.value_components == 4);
+	ufbxt_assert(material->pbr.coat_factor.value_components == 1);
+	ufbxt_assert(material->pbr.coat_color.value_components == 4);
+	ufbxt_assert(material->pbr.coat_roughness.value_components == 1);
+	ufbxt_assert(material->pbr.normal_map.value_components == 1);
+	ufbxt_assert(material->pbr.coat_normal.value_components == 1);
+	ufbxt_assert(material->pbr.displacement_map.value_components == 1);
+	ufbxt_assert(material->pbr.opacity.value_components == 0);
+
+	ufbxt_assert(material->features.diffuse.enabled);
+	ufbxt_assert(material->features.metalness.enabled);
+	ufbxt_assert(material->features.specular.enabled);
+	ufbxt_assert(material->features.coat.enabled);
+	ufbxt_assert(material->features.sheen.enabled);
+	ufbxt_assert(material->features.transmission.enabled);
+	ufbxt_assert(material->features.opacity.enabled);
+	ufbxt_assert(material->features.ior.enabled);
+	ufbxt_assert(material->features.diffuse_roughness.enabled);
+	ufbxt_assert(material->features.thin_walled.enabled);
+	ufbxt_assert(material->features.thin_walled.is_explicit);
+}
+#endif
+
 UFBXT_FILE_TEST(blender_279_internal_textures)
 #if UFBXT_IMPL
 {
@@ -907,6 +1066,7 @@ UFBXT_FILE_TEST(maya_arnold_properties)
 
 	// Computed
 	ufbxt_assert_close_real(err, material->pbr.transmission_roughness.value_real, 0.36f); // 11+25
+	ufbxt_assert(err, material->pbr.thin_film_factor.value_real == 1.0f);
 
 	ufbxt_assert(material->pbr.base_factor.value_components == 1);
 	ufbxt_assert(material->pbr.base_color.value_components == 3);
@@ -1044,6 +1204,7 @@ UFBXT_FILE_TEST(maya_osl_properties)
 
 	// Computed
 	ufbxt_assert_close_real(err, material->pbr.transmission_roughness.value_real, 0.36f); // 11+25
+	ufbxt_assert(err, material->pbr.thin_film_factor.value_real == 1.0f);
 
 	ufbxt_assert(material->features.thin_walled.enabled);
 	ufbxt_assert(material->features.thin_walled.is_explicit);

--- a/ufbx.c
+++ b/ufbx.c
@@ -18978,6 +18978,8 @@ typedef enum {
 	UFBXI_SHADER_MAPPING_DEFAULT_W_1 = 0x1,
 	// Widen values to RGB if only a single value is present.
 	UFBXI_SHADER_MAPPING_WIDEN_TO_RGB = 0x2,
+	// Multiply the existing value.
+	UFBXI_SHADER_MAPPING_MULTIPLY_VALUE = 0x4,
 } ufbxi_shader_mapping_flag;
 
 typedef enum {
@@ -19283,6 +19285,56 @@ static const ufbxi_shader_mapping ufbxi_gltf_material_pbr_mapping[] = {
 	{ UFBX_MATERIAL_PBR_SPECULAR_IOR, 0, 0, ufbxi_mat_string("extension|indexOfRefraction") },
 };
 
+static const ufbxi_shader_mapping ufbxi_openpbr_material_pbr_mapping[] = {
+	{ UFBX_MATERIAL_PBR_BASE_FACTOR, 0, 0, ufbxi_mat_string("base_weight") },
+	{ UFBX_MATERIAL_PBR_BASE_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("base_color") },
+	{ UFBX_MATERIAL_PBR_ROUGHNESS, 0, 0, ufbxi_mat_string("specular_roughness") },
+	{ UFBX_MATERIAL_PBR_DIFFUSE_ROUGHNESS, 0, 0, ufbxi_mat_string("base_diffuse_roughness") },
+	{ UFBX_MATERIAL_PBR_METALNESS, 0, 0, ufbxi_mat_string("base_metalness") },
+	{ UFBX_MATERIAL_PBR_SPECULAR_FACTOR, 0, 0, ufbxi_mat_string("specular_weight") },
+	{ UFBX_MATERIAL_PBR_SPECULAR_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("specular_color") },
+	{ UFBX_MATERIAL_PBR_SPECULAR_ANISOTROPY, 0, 0, ufbxi_mat_string("specular_roughness_anisotropy") },
+	{ UFBX_MATERIAL_PBR_SPECULAR_IOR, 0, 0, ufbxi_mat_string("specular_ior") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_FACTOR, 0, 0, ufbxi_mat_string("transmission_weight") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("transmission_color") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_DEPTH, 0, 0, ufbxi_mat_string("transmission_depth") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_SCATTER, UFBXI_SHADER_MAPPING_WIDEN_TO_RGB, 0, ufbxi_mat_string("transmission_scatter") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_SCATTER_ANISOTROPY, 0, 0, ufbxi_mat_string("transmission_scatter_anisotropy") },
+	{ UFBX_MATERIAL_PBR_TRANSMISSION_DISPERSION, 0, 0, ufbxi_mat_string("transmission_dispersion_scale") },
+	{ UFBX_MATERIAL_PBR_SUBSURFACE_FACTOR, 0, 0, ufbxi_mat_string("subsurface_weight") },
+	{ UFBX_MATERIAL_PBR_SUBSURFACE_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("subsurface_color") },
+	{ UFBX_MATERIAL_PBR_SUBSURFACE_RADIUS, UFBXI_SHADER_MAPPING_WIDEN_TO_RGB, 0, ufbxi_mat_string("subsurface_radius_scale") },
+	{ UFBX_MATERIAL_PBR_SUBSURFACE_SCALE, 0, 0, ufbxi_mat_string("subsurface_radius") },
+	{ UFBX_MATERIAL_PBR_SUBSURFACE_ANISOTROPY, 0, 0, ufbxi_mat_string("subsurface_scatter_anisotropy") },
+	{ UFBX_MATERIAL_PBR_COAT_FACTOR, 0, 0, ufbxi_mat_string("coat_weight") },
+	{ UFBX_MATERIAL_PBR_COAT_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("coat_color") },
+	{ UFBX_MATERIAL_PBR_COAT_ROUGHNESS, 0, 0, ufbxi_mat_string("coat_roughness") },
+	{ UFBX_MATERIAL_PBR_COAT_ANISOTROPY, 0, 0, ufbxi_mat_string("coat_roughness_anisotropy") },
+	{ UFBX_MATERIAL_PBR_COAT_IOR, 0, 0, ufbxi_mat_string("coat_ior") },
+	{ UFBX_MATERIAL_PBR_COAT_NORMAL, 0, 0, ufbxi_mat_string("coat_normal_map") },
+	{ UFBX_MATERIAL_PBR_SHEEN_FACTOR, 0, 0, ufbxi_mat_string("fuzz_weight") },
+	{ UFBX_MATERIAL_PBR_SHEEN_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("fuzz_color") },
+	{ UFBX_MATERIAL_PBR_SHEEN_ROUGHNESS, 0, 0, ufbxi_mat_string("fuzz_roughness") },
+	{ UFBX_MATERIAL_PBR_EMISSION_FACTOR, 0, 0, ufbxi_mat_string("emission_weight") },
+	{ UFBX_MATERIAL_PBR_EMISSION_FACTOR, UFBXI_SHADER_MAPPING_MULTIPLY_VALUE, 0, ufbxi_mat_string("emission_luminance") },
+	{ UFBX_MATERIAL_PBR_EMISSION_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("emission_color") },
+	{ UFBX_MATERIAL_PBR_THIN_FILM_FACTOR, 0, 0, ufbxi_mat_string("thin_film_weight") },
+	{ UFBX_MATERIAL_PBR_THIN_FILM_THICKNESS, 0, 0, ufbxi_mat_string("thin_film_thickness") },
+	{ UFBX_MATERIAL_PBR_THIN_FILM_IOR, 0, 0, ufbxi_mat_string("thin_film_ior") },
+	{ UFBX_MATERIAL_PBR_NORMAL_MAP, 0, 0, ufbxi_mat_string("bump") },
+	{ UFBX_MATERIAL_PBR_NORMAL_MAP, 0, 0, ufbxi_mat_string("bump_map_amt") },
+	{ UFBX_MATERIAL_PBR_DISPLACEMENT_MAP, 0, 0, ufbxi_mat_string("displacement") },
+	{ UFBX_MATERIAL_PBR_DISPLACEMENT_MAP, 0, 0, ufbxi_mat_string("displacement_map_amt") },
+	{ UFBX_MATERIAL_PBR_COAT_NORMAL, 0, 0, ufbxi_mat_string("coat_bump") },
+	{ UFBX_MATERIAL_PBR_COAT_NORMAL, 0, 0, ufbxi_mat_string("coat_bump_map_amt") },
+	{ UFBX_MATERIAL_PBR_TANGENT_MAP, 0, 0, ufbxi_mat_string("geometry_tangent_map") },
+	{ UFBX_MATERIAL_PBR_OPACITY, UFBXI_SHADER_MAPPING_WIDEN_TO_RGB, 0, ufbxi_mat_string("geometry_opacity") },
+};
+
+static const ufbxi_shader_mapping ufbxi_openpbr_material_features[] = {
+	{ UFBX_MATERIAL_FEATURE_THIN_WALLED, 0, 0, ufbxi_mat_string("geometry_thin_walled") },
+};
+
 static const ufbxi_shader_mapping ufbxi_3ds_max_pbr_metal_rough_pbr_mapping[] = {
 	{ UFBX_MATERIAL_PBR_BASE_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("base_color") },
 	{ UFBX_MATERIAL_PBR_BASE_COLOR, UFBXI_SHADER_MAPPING_DEFAULT_W_1, 0, ufbxi_mat_string("baseColor") },
@@ -19461,6 +19513,14 @@ static const ufbxi_shader_mapping_list ufbxi_shader_pbr_mappings[] = {
 		{ NULL, 0 }, ufbxi_string_literal("Map"), // texture_prefix/suffix
 		{ NULL, 0 }, { NULL, 0 }, // texture_enabled_prefix/suffix
 	},
+	{ // UFBX_SHADER_OPENPBR_MATERIAL
+		ufbxi_openpbr_material_pbr_mapping, ufbxi_arraycount(ufbxi_openpbr_material_pbr_mapping),
+		ufbxi_openpbr_material_features, ufbxi_arraycount(ufbxi_openpbr_material_features),
+		(uint32_t)(UFBXI_MAT_PBR | UFBXI_MAT_METALNESS | UFBXI_MAT_DIFFUSE | UFBXI_MAT_SPECULAR | UFBXI_MAT_COAT
+			| UFBXI_MAT_SHEEN | UFBXI_MAT_TRANSMISSION | UFBXI_MAT_OPACITY | UFBXI_MAT_IOR | UFBXI_MAT_DIFFUSE_ROUGHNESS),
+		{ NULL, 0 }, ufbxi_string_literal("_map"),    // texture_prefix/suffix
+		{ NULL, 0 }, ufbxi_string_literal("_map_on"), // texture_enabled_prefix/suffix
+	},
 	{ // UFBX_SHADER_SHADERFX_GRAPH
 		ufbxi_shaderfx_graph_pbr_mapping, ufbxi_arraycount(ufbxi_shaderfx_graph_pbr_mapping),
 		NULL, 0,
@@ -19564,8 +19624,13 @@ ufbxi_noinline static void ufbxi_fetch_mapping_maps(ufbx_material *material, ufb
 
 			if (flags & UFBXI_MAPPING_FETCH_VALUE) {
 				if (prop && prop->type != UFBX_PROP_REFERENCE) {
-					map->value_vec4 = prop->value_vec4;
-					map->value_int = prop->value_int;
+					if ((mapping->flags & UFBXI_SHADER_MAPPING_MULTIPLY_VALUE) != 0) {
+						map->value_vec4.x *= prop->value_vec4.x;
+						map->value_int = ufbxi_f64_to_i64(map->value_vec4.x);
+					} else {
+						map->value_vec4 = prop->value_vec4;
+						map->value_int = prop->value_int;
+					}
 					map->has_value = true;
 					if (mapping->transform) {
 						ufbxi_mat_transform_fn transform_fn = ufbxi_mat_transform_fns[mapping->transform];
@@ -19707,6 +19772,7 @@ ufbxi_noinline static void ufbxi_fetch_maps(ufbx_scene *scene, ufbx_material *ma
 	ufbxi_update_factor(&material->pbr.specular_factor, &material->pbr.specular_color);
 	ufbxi_update_factor(&material->pbr.emission_factor, &material->pbr.emission_color);
 	ufbxi_update_factor(&material->pbr.sheen_factor, &material->pbr.sheen_color);
+	ufbxi_update_factor(&material->pbr.thin_film_factor, &material->pbr.thin_film_thickness);
 	ufbxi_update_factor(&material->pbr.transmission_factor, &material->pbr.transmission_color);
 
 	// Patch transmission roughness if only extra roughness is defined
@@ -20005,6 +20071,7 @@ static const ufbxi_file_shader ufbxi_file_shaders[] = {
 	{ UINT64_C(0x7e73161fad53b12a), "ai_image", "filename" },
 	{ 0, "OSLBitmap", ufbxi_Filename },
 	{ 0, "OSLBitmap2", ufbxi_Filename },
+	{ 0, "OSLBitmap3", ufbxi_Filename },
 	{ 0, "UberBitmap", ufbxi_Filename },
 	{ 0, "UberBitmap2", ufbxi_Filename },
 };
@@ -21840,6 +21907,10 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_finalize_scene(ufbxi_context *uc
 				uint32_t classid_b = (uint32_t)(uint64_t)ufbx_find_int(&material->props, "3dsMax|ClassIDb", 0);
 				if (classid_a == 0x3d6b1cecu && classid_b == 0xdeadc001u) {
 					material->shader_type = UFBX_SHADER_3DS_MAX_PHYSICAL_MATERIAL;
+					material->shader_prop_prefix.data = "3dsMax|Parameters|";
+					material->shader_prop_prefix.length = strlen("3dsMax|Parameters|");
+				} else if (classid_a == 0xf1551e33u && classid_b == 0x37fb1337u) {
+					material->shader_type = UFBX_SHADER_OPENPBR_MATERIAL;
 					material->shader_prop_prefix.data = "3dsMax|Parameters|";
 					material->shader_prop_prefix.length = strlen("3dsMax|Parameters|");
 				} else if (classid_a == 0x38420192u && classid_b == 0x45fe4e1bu) {

--- a/ufbx.h
+++ b/ufbx.h
@@ -2353,6 +2353,9 @@ typedef enum ufbx_shader_type UFBX_ENUM_REPR {
 	// 3ds glTF Material
 	// https://help.autodesk.com/view/3DSMAX/2023/ENU/?guid=GUID-7ABFB805-1D9F-417E-9C22-704BFDF160FA
 	UFBX_SHADER_GLTF_MATERIAL,
+	// 3ds OpenPBR Material
+	// https://help.autodesk.com/view/3DSMAX/2025/ENU/?guid=GUID-CD90329C-1E2B-4BBA-9285-3BB46253B9C2
+	UFBX_SHADER_OPENPBR_MATERIAL,
 	// Stingray ShaderFX shader graph.
 	// Contains a serialized `"ShaderGraph"` in `ufbx_props`.
 	UFBX_SHADER_SHADERFX_GRAPH,
@@ -2437,6 +2440,7 @@ typedef enum ufbx_material_pbr_map UFBX_ENUM_REPR {
 	UFBX_MATERIAL_PBR_COAT_NORMAL,
 	UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_COLOR,
 	UFBX_MATERIAL_PBR_COAT_AFFECT_BASE_ROUGHNESS,
+	UFBX_MATERIAL_PBR_THIN_FILM_FACTOR,
 	UFBX_MATERIAL_PBR_THIN_FILM_THICKNESS,
 	UFBX_MATERIAL_PBR_THIN_FILM_IOR,
 	UFBX_MATERIAL_PBR_EMISSION_FACTOR,
@@ -2561,6 +2565,7 @@ typedef struct ufbx_material_pbr_maps {
 			ufbx_material_map coat_normal;
 			ufbx_material_map coat_affect_base_color;
 			ufbx_material_map coat_affect_base_roughness;
+			ufbx_material_map thin_film_factor;
 			ufbx_material_map thin_film_thickness;
 			ufbx_material_map thin_film_ior;
 			ufbx_material_map emission_factor;


### PR DESCRIPTION
See #195. Currently only implemented on 3ds Max, as Maya does not seem to export these materials.

The material definition is mostly straightforward, but has one annoying detail: It defines two values for emission intensity: weight and luminance. The current implementation multiplies both properties to `emission_factor`, as all other material models use a single weight so far. Textures are supported from either property, and the luminance texture is preferred.

Exposing the split factor would be cleaner, but would complicate all user code as they'd need to handle it, assuming that this material is quite rare. It could be defaulted to 1.0, but then users would still need to search for textures in two places.