### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/misc/run_tests.py
+++ b/misc/run_tests.py
@@ -180,7 +180,7 @@ class CLCompiler(Compiler):
 
     async def check_version(self):
         _, out, err, _, _ = await self.run()
-        m = re.search(r"Version ([.0-9]+) for (\w+)", out + err, re.M)
+        m = re.search(r"Version ([.0-9]+) for (\w+)", out + err, flags=re.M)
         if not m: return False
         self.arch = m.group(2).lower()
         self.version = m.group(1)
@@ -461,7 +461,7 @@ class TCCCompiler(GCCCompiler):
     async def check_version(self):
         _, out, err, _, _ = await self.run("-v")
         print(out + err)
-        m = re.search(r"tcc version ([.0-9]+) \((\w+).*\)", out + err, re.M)
+        m = re.search(r"tcc version ([.0-9]+) \((\w+).*\)", out + err, flags=re.M)
         if not m: return False
         self.arch = m.group(2).lower()
         self.version = m.group(1)
@@ -582,13 +582,13 @@ for sdk in argv.wasi_sdk:
 for desc in argv.additional_compiler:
     name = re.sub(r"[^A-Za-z0-9\-]", "", desc)
     if "clang" in desc:
-        cpp = re.sub(r"clang", "clang++", desc, 1)
+        cpp = re.sub(r"clang", "clang++", desc, count=1)
         all_compilers += [
             ClangCompiler(name, desc, False),
             ClangCompiler(name, cpp, True),
         ]
     elif "gcc" in desc:
-        cpp = re.sub(r"gcc", "g++", desc, 1)
+        cpp = re.sub(r"gcc", "g++", desc, count=1)
         all_compilers += [
             GCCCompiler(name, desc, False),
             GCCCompiler(name, cpp, True),


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+ which you can see in the [CI logs](https://github.com/ufbx/ufbx/actions/runs/14574119447/job/40876633359#step:4:5):
```python
/Users/runner/work/ufbx/ufbx/misc/run_tests.py:591: DeprecationWarning: 'count' is passed as positional argument
```