### PR TITLE
Integration v0.20.0

### DIFF
--- a/bindgen/ufbx_ir.py
+++ b/bindgen/ufbx_ir.py
@@ -833,6 +833,14 @@ member_functions = [
     MemberFunction(func="ufbx_sample_geometry_cache_vec3", self_type="ufbx_cache_channel", member_name="sample_vec3"),
     MemberFunction(func="ufbx_dom_find_len", self_type="ufbx_dom_node", member_name="find_len"),
     MemberFunction(func="ufbx_dom_find", self_type="ufbx_dom_node", member_name="find"),
+    MemberFunction(func="ufbx_dom_is_array", self_type="ufbx_dom_node", member_name="is_array"),
+    MemberFunction(func="ufbx_dom_array_size", self_type="ufbx_dom_node", member_name="array_size"),
+    MemberFunction(func="ufbx_dom_as_int32_list", self_type="ufbx_dom_node", member_name="as_int32_list"),
+    MemberFunction(func="ufbx_dom_as_int64_list", self_type="ufbx_dom_node", member_name="as_int64_list"),
+    MemberFunction(func="ufbx_dom_as_float_list", self_type="ufbx_dom_node", member_name="as_float_list"),
+    MemberFunction(func="ufbx_dom_as_double_list", self_type="ufbx_dom_node", member_name="as_double_list"),
+    MemberFunction(func="ufbx_dom_as_real_list", self_type="ufbx_dom_node", member_name="as_real_list"),
+    MemberFunction(func="ufbx_dom_as_blob_list", self_type="ufbx_dom_node", member_name="as_blob_list"),
 ]
 
 member_globals = [

--- a/ufbx.c
+++ b/ufbx.c
@@ -874,7 +874,7 @@ enum { UFBX_MAXIMUM_ALIGNMENT = sizeof(void*) > 8 ? sizeof(void*) : 8 };
 
 // -- Version
 
-#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 19, 0)
+#define UFBX_SOURCE_VERSION ufbx_pack_version(0, 20, 0)
 ufbx_abi_data_def const uint32_t ufbx_source_version = UFBX_SOURCE_VERSION;
 
 ufbx_static_assert(source_header_version, UFBX_SOURCE_VERSION/1000u == UFBX_HEADER_VERSION/1000u);

--- a/ufbx.c
+++ b/ufbx.c
@@ -407,8 +407,10 @@ extern "C" {
 
 #if defined(__GNUC__)
 	#define UFBXI_GNUC __GNUC__
+	#define UFBXI_GNUC_VERSION ufbx_pack_version(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #else
 	#define UFBXI_GNUC 0
+	#define UFBXI_GNUC_VERSION 0
 #endif
 
 #if !defined(UFBX_STANDARD_C) && defined(_MSC_VER)
@@ -539,6 +541,10 @@ extern "C" {
 	// MSC isnan() definition triggers this error on MinGW GCC
 	#if defined(__MINGW32__)
 		#pragma GCC diagnostic ignored "-Wfloat-conversion"
+	#endif
+	// `-Warray-bounds` results in warnings if UBsan is enabled and pre-GCC-14 has no way of detecting it..
+	#if UFBXI_GNUC_VERSION >= ufbx_pack_version(4, 3, 0) && UFBXI_GNUC_VERSION < ufbx_pack_version(14, 0, 0)
+		#pragma GCC diagnostic ignored "-Warray-bounds"
 	#endif
 #endif
 

--- a/ufbx.h
+++ b/ufbx.h
@@ -267,7 +267,7 @@ struct ufbx_converter { };
 // `ufbx_source_version` contains the version of the corresponding source file.
 // HINT: The version can be compared numerically to the result of `ufbx_pack_version()`,
 // for example `#if UFBX_VERSION >= ufbx_pack_version(0, 12, 0)`.
-#define UFBX_HEADER_VERSION ufbx_pack_version(0, 19, 0)
+#define UFBX_HEADER_VERSION ufbx_pack_version(0, 20, 0)
 #define UFBX_VERSION UFBX_HEADER_VERSION
 
 // -- Basic types

--- a/ufbx.h
+++ b/ufbx.h
@@ -257,7 +257,7 @@ struct ufbx_converter { };
 // -- Version
 
 // Packing/unpacking for `UFBX_HEADER_VERSION` and `ufbx_source_version`.
-#define ufbx_pack_version(major, minor, patch) ((uint32_t)(major)*1000000u + (uint32_t)(minor)*1000u + (uint32_t)(patch))
+#define ufbx_pack_version(major, minor, patch) ((major)*1000000u + (minor)*1000u + (patch))
 #define ufbx_version_major(version) ((uint32_t)(version)/1000000u%1000u)
 #define ufbx_version_minor(version) ((uint32_t)(version)/1000u%1000u)
 #define ufbx_version_patch(version) ((uint32_t)(version)%1000u)


### PR DESCRIPTION
- Make `ufbx_pack_version()` actually work in preprocessor
- Fix GCC `-Warray-bounds` (#222)