### PR TITLE
Add wasm64 support

### DIFF
--- a/ufbx.c
+++ b/ufbx.c
@@ -860,7 +860,7 @@ enum { UFBX_MAXIMUM_ALIGNMENT = sizeof(void*) > 8 ? sizeof(void*) : 8 };
 #endif
 
 #if !defined(UFBX_POINTER_SIZE) && !defined(UFBX_STANDARD_C)
-	#if (defined(_M_X64) || defined(__x86_64__) || defined(_M_ARM64) || defined(__aarch64__)) && !defined(__CHERI__)
+	#if (defined(__wasm64__) || defined(_M_X64) || defined(__x86_64__) || defined(_M_ARM64) || defined(__aarch64__)) && !defined(__CHERI__)
 		#define UFBX_POINTER_SIZE 8
 	#elif defined(__wasm__) || defined(__EMSCRIPTEN__)
 		#define UFBX_POINTER_SIZE 4


### PR DESCRIPTION
Otherwise `UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFU` would do the trick as well