### PR TITLE
Rename main branch

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,11 +3,11 @@ coverage:
     project:
       default:
         informational: true
-      master:
+      main:
         informational: false
         target: 95%
         branches: 
-          - master
+          - main
     patch:
       default:
         informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, integration ]
+    branches: [ main, integration ]
 
 # Cancel any in-flight jobs for the same PR/branch so there's only one active
 # at a time

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -2,9 +2,9 @@ name: Pre-deploy
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 # Cancel any in-flight jobs for the same PR/branch so there's only one active
 # at a time

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -28,21 +28,6 @@ jobs:
           bash misc/users/magnum-plugins/build.sh
           bash misc/users/magnum-plugins/run.sh
 
-  pd_rust:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: ufbx/ufbx-rust/.github/workflows/test.yml@main
-    with:
-      ufbx-rust-ref: main
-      ufbx-ref: ${{ github.ref }}
-
-  pd_documentation:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: ufbx/ufbx.github.io/.github/workflows/test.yml@integration
-    with:
-      ufbx-documentation-ref: integration
-      ufbx-rust-ref: main
-      ufbx-ref: ${{ github.ref }}
-
   pd_picort:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rename `master` to `main`.

Also removed pre-deploy rust and documentation checks, as they are now a part of the release system